### PR TITLE
Add a tabindex into the search form.

### DIFF
--- a/classes/searches.php
+++ b/classes/searches.php
@@ -36,7 +36,7 @@ class Searches {
 return '
 	<FORM ACTION="' . $this->SearchPage . '" NAME="f">
 	Enter Keywords:<BR>
-	<INPUT NAME="query"  TYPE="text" SIZE="8">' . $text . '<INPUT TYPE="submit" VALUE="go" NAME="search">
+	<INPUT NAME="query"  TYPE="text" SIZE="8" TABINDEX=1>' . $text . '<INPUT TYPE="submit" VALUE="go" NAME="search" TABINDEX=2>
 	<INPUT NAME="num"             TYPE="hidden" value="' . FRESHPORTS_SEARCH_DEFAULT_Num             . '">
 	<INPUT NAME="stype"           TYPE="hidden" value="' . FRESHPORTS_SEARCH_DEFAULT_Stype           . '">
 	<INPUT NAME="method"          TYPE="hidden" value="' . FRESHPORTS_SEARCH_DEFAULT_Method          . '">


### PR DESCRIPTION
This allows one to get to the search form by just hitting tab once
instead of having to tab through many links before you get to the
search form. As far as I can tell, there is no other specific tab
order set and this seems much better than what was there previously.

As someone who likes to get to the search box quickly by using the keyboard, this helps a lot.