### PR TITLE
Remove PortsMon links

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -141,7 +141,6 @@ class port_display {
 		$this->ShowMasterSlave         = false;
 		$this->ShowPackageLink         = false;
 		$this->ShowPortCreationDate    = false;
-		$this->ShowPortsMonLink        = false;
 		$this->ShowConfigurePlist      = false;
 		$this->ShowShortDescription    = false;
 		$this->ShowWatchListCount      = false;
@@ -164,7 +163,6 @@ class port_display {
 		$this->ShowHomepageLink        = true;
 		$this->ShowMaintainedBy        = true;
 		$this->ShowPortCreationDate    = true;
-		$this->ShowPortsMonLink        = true;
 		$this->ShowPackageLink         = true;
 		$this->ShowShortDescription    = true;
 		$this->ShowWatchListStatus     = true;
@@ -492,10 +490,6 @@ class port_display {
 		if ($port->homepage && ($this->ShowHomepageLink || $this->ShowEverything)) {
 			$HTML .= ' <b>:</b> ';
 			$HTML .= '<a HREF="' . _forDisplay($port->homepage) . '" TITLE="Homepage for this port">Homepage</a>';
-		}
-
-		if (defined('PORTSMONSHOW')  && ($this->ShowPortsMonLink || $this->ShowEverything)) {
-			$HTML .= ' <b>:</b> ' . freshports_PortsMonitorURL($port->category, $port->port);
 		}
 
 		if (defined('CONFIGUREPLISTSHOW')  && ($this->ShowConfigurePlist || $this->ShowEverything)) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -2014,16 +2014,6 @@ function PeopleWatchingThisPortAlsoWatch($dbh, $element_id) {
 }
 
 
-function freshports_PortsMonitorURL($Category, $Port) {
-	# we have a problem with + in portnames.
-	# works: http://portsmon.freebsd.org/portoverview.py?category=editors&portname=vim6%2Bruby
-	# fails: http://portsmon.freebsd.org/portoverview.py?category=editors&portname=vim6+ruby
-	#
-	return '<a href="' . PORTSMONURL . '?category=' . urlencode($Category) . '&amp;portname=' . urlencode($Port) . '" title="Ports Monitor">PortsMon</a>';
-}
-
-
-
 function freshports_RedirectPermanent($URL) {
 	#
 	# My thanks to nne van Kesteren who posted this solution


### PR DESCRIPTION
These links are pointing to a page that indicates that portsmon.freebsd.org have been broken for two years (only the home page displays correctly).

Maybe it make sense to drop them now?