### PR TITLE
`pre` CSS style fix

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -6,7 +6,7 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}
-PRE.code {  color: #461b7e; white-space: pre-wrap}
+PRE.code {  color: #461b7e; white-space: pre-wrap; word-break: break-word}
 
 .like-pre {
   color: #461b7e;


### PR DESCRIPTION
If the text in `pre` tag is too long, there's a horizontal scrollbar for a whole page and you have to scroll to see the sidebar.

Before:
![Snímek obrazovky - 24 3 2021 - 08:36:25](https://user-images.githubusercontent.com/14090004/112272296-508a3400-8c7c-11eb-97bb-dfa29b8305e3.png)

After:
![Snímek obrazovky - 24 3 2021 - 08:36:09](https://user-images.githubusercontent.com/14090004/112272343-5e3fb980-8c7c-11eb-91ac-82d92d00102d.png)