### PR TITLE
RSS Validation Fixes

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1746,7 +1746,8 @@ alt="powered by apache" border="0" width="259" height="32"></a>
 ';
 	}
 
-	$URI = trim(urlencode($_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']));
+	$URIBase = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'];
+	$URI = trim(urlencode($URIBase . $_SERVER['REQUEST_URI']));
 
 	$HTML .= '
 <tr><td>
@@ -1760,7 +1761,7 @@ alt="powered by apache" border="0" width="259" height="32"></a>
 Valid 
 <a href="https://validator.w3.org/check?uri=' . $URI . '" title="We like to keep our HTML valid" target="_blank">HTML</a>, 
 <a href="https://jigsaw.w3.org/css-validator/validator?uri=' .  $URI . '" title="We like to have valid CSS">CSS</a>, and
-<a href="https://feedvalidator.org/check.cgi?url=https://' . $_SERVER['HTTP_HOST'] . '/backend/rss2.0.php" title="Valid RSS is good too">RSS</a>.
+<a href="https://validator.w3.org/feed/check.cgi?url=' . rawurlencode("{$URIBase}/backend/rss2.0.php") . '" title="Valid RSS is good too">RSS</a>.
 </small>
 <br>' . freshports_copyright() . '
 </td></tr>

--- a/www/backend/index.php
+++ b/www/backend/index.php
@@ -54,9 +54,9 @@ $Hostname = $_SERVER['HTTP_HOST'];
 <li><a href="mbox.php">mbox</a>
 <li><a href="opml.php">opml</a>
 <li><a href="pie0.1.php">PIE 0.1</a>
-<li><a href="rss0.91.php">RSS 0.91</a> [ <a href="http://feedvalidator.org/check.cgi?url=<?php echo $Protocol; ?>%3A//<?php echo $Hostname; ?>/backend/rss0.91.php">RSS Feed validator</a> ]
-<li><a href="rss1.0.php">RSS 1.0</a>   [ <a href="http://feedvalidator.org/check.cgi?url=<?php echo $Protocol; ?>%3A//<?php echo $Hostname; ?>/backend/rss1.0.php">RSS Feed validator</a>  ]
-<li><a href="rss2.0.php">RSS 2.0</a>   [ <a href="http://feedvalidator.org/check.cgi?url=<?php echo $Protocol; ?>%3A//<?php echo $Hostname; ?>/backend/rss2.0.php">RSS Feed validator</a>  ]
+<li><a href="rss0.91.php">RSS 0.91</a> [ <a href="https://validator.w3.org/feed/check.cgi?url=<?php echo rawurlencode("{$Protocol}://{$Hostname}/backend/rss0.91.php"); ?>">RSS Feed validator</a> ]
+<li><a href="rss1.0.php">RSS 1.0</a>   [ <a href="https://validator.w3.org/feed/check.cgi?url=<?php echo rawurlencode("{$Protocol}://{$Hostname}/backend/rss1.0.php"); ?>">RSS Feed validator</a>  ]
+<li><a href="rss2.0.php">RSS 2.0</a>   [ <a href="https://validator.w3.org/feed/check.cgi?url=<?php echo rawurlencode("{$Protocol}://{$Hostname}/backend/rss2.0.php"); ?>">RSS Feed validator</a>  ]
 </ol>
 
 <p>


### PR DESCRIPTION
Looks like feedvalidator.org doesn't work anymore, so this PR changes the validation service to the [W3C one](https://validator.w3.org/feed/) (which looks to use produce the same results as the [RSS Board validator](https://www.rssboard.org/rss-validator/), which says it uses the feedvalidator.org one, so it should in essence be the same as before.