### PR TITLE
Clean up setfocus()

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1002,17 +1002,9 @@ function freshports_style($Phorum=0) {
 
 function freshports_body($ExtraScript = null) {
 
-GLOBAL $OnLoad;
 GLOBAL $Debug;
 
-echo "\n" . '<BODY bgcolor="#FFFFFF" TEXT="#000000" ';
-
-# should we have an onload?
-if ($OnLoad) {
-	echo ' onLoad="' . $OnLoad . '"';
-}
-
-echo ">\n\n";
+echo "\n" . '<BODY bgcolor="#FFFFFF" TEXT="#000000">';
 
 # most often used for page setup, hiding elements, etc
 if (!empty($ExtraScript)) {

--- a/include/login.php
+++ b/include/login.php
@@ -11,7 +11,7 @@
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" name="l">
       <input type="hidden" name="custom_settings" value="1"><input type="hidden" name="LOGIN" value="1">
       <p>User ID:<br>
-      <input SIZE="15" NAME="UserID" value="<?php if (IsSet($UserID)) echo htmlentities($UserID) ?>"></p>
+      <input SIZE="15" NAME="UserID" value="<?php if (IsSet($UserID)) echo htmlentities($UserID) ?>" autofocus=""></p>
       <p>Password:<br>
       <input TYPE="PASSWORD" NAME="Password" VALUE = "<?php if (IsSet($Password)) echo htmlentities($Password) ?>" size="20"></p>
       <p><input TYPE="submit" VALUE="Login" name=submit>

--- a/include/new-user.php
+++ b/include/new-user.php
@@ -15,7 +15,7 @@
 <?php if (!IsSet($Customize)) { ?>
               <INPUT TYPE="hidden" NAME="ADD" VALUE="1">
               User ID:<br>
-              <INPUT SIZE="15" NAME="UserLogin" VALUE="<?php if (IsSet($UserLogin)) echo htmlentities($UserLogin) ?>"><br><br>
+              <INPUT SIZE="15" NAME="UserLogin" VALUE="<?php if (IsSet($UserLogin)) echo htmlentities($UserLogin) ?>" autofocus=""><br><br>
 <?php } ?>
                Password:<br>
                <INPUT TYPE="PASSWORD" NAME="Password1" VALUE="<?php if (IsSet($Password1)) echo htmlentities($Password1) ?>" size="20"><br><br>

--- a/www/index.php
+++ b/www/index.php
@@ -26,10 +26,6 @@
 
 	if ($Debug) echo 'Branch is ' . $Branch . '<br>';
 
-	if ($User->set_focus_search) {
-		$OnLoad = 'setfocus()';
-	}
-
 	#
 	# If they supply a package name, go for it.
 	#
@@ -69,13 +65,6 @@
 	    if ($Debug) echo "package is not specified on the URL<br>\n";
     }
 ?>
-
-<script language="JavaScript" type="text/javascript">
-<!--
-function setfocus() { document.f.query.focus(); }
-// -->
-</script>
-
 <?php
 	$Title = 'Most recent commits';
 	freshports_Start($FreshPortsSlogan . " - $Title",
@@ -257,6 +246,12 @@ echo '&lt; ' . $Yesterday . ' &gt;';
 <?
 echo freshports_ShowFooter();
 ?>
-
+<? if ($User->set_focus_search) { ?>
+	<script language="JavaScript" type="text/javascript">
+	<!--
+	document.f.query.focus();
+	// -->
+	</script>
+<? } ?>
 </body>
 </html>

--- a/www/login.php
+++ b/www/login.php
@@ -134,19 +134,12 @@ if (IsSet($_GET["resend"])) {
 
 
 <?php
-	$OnLoad = 'setfocus()';
 	$Title = 'Login';
 	freshports_Start($Title,
                $Title,
                'FreeBSD, index, applications, ports');
 
 ?>
-
-<script language="JavaScript" type="text/javascript">
-<!--
-function setfocus() { document.l.UserID.focus(); }
-// -->
-</script>
 
 <?php echo freshports_MainTable(); ?>
  <TR>

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -176,12 +176,6 @@ if (IsSet($submit)) {
                'FreeBSD, index, applications, ports');
 ?>
 
-<SCRIPT TYPE="text/javascript">
-<!--
-function setfocus() { document.f.UserLogin.focus(); }
-// -->
-</SCRIPT>
-
 <?php echo freshports_MainTable(); ?>
 <TR><TD VALIGN="top" WIDTH="100%">
 <?php

--- a/www/search.php
+++ b/www/search.php
@@ -289,10 +289,6 @@ if ($output_format == OUTPUT_FORMAT_PLAIN_TEXT || $output_format == OUTPUT_FORMA
   header('Content-Type: text/plain');
 }
 
-if (!IsSet($_REQUEST['query'])) {
-	$OnLoad = 'setfocus()';
-}
-
 if ($output_format == OUTPUT_FORMAT_HTML) {
 	$Title = 'Search';
 	freshports_Start($Title,
@@ -301,11 +297,6 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 ?>
 
-<script language="JavaScript" type="text/javascript">
-<!--
-function setfocus() { document.search.query.focus(); }
-// -->
-</script>
 
 <?php echo freshports_MainTable(); ?>
 <tr><td valign="top" width="100%">
@@ -1158,7 +1149,13 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 echo freshports_ShowFooter();
 
 ?>
-
+<? if (!IsSet($_REQUEST['query'])) { ?>
+<script language="JavaScript" type="text/javascript">
+<!--
+document.search.query.focus();
+// -->
+</script>
+<? } ?>
 </body>
 </html>
 


### PR DESCRIPTION
For the homepage, the `setfocus`-defining `script` tag is preceding the `DOCTYPE` definition, putting the document in quirks mode and preventing meaningful HTML validation.

This PR cleans up the usage of the `setfocus()` function pattern.

Rather than declaring a JS function, and passing knowledge of that function around via the `$OnLoad` global variable to be executed during the `body` element's `load` event, we just execute the function body at the end of the body element. This has the same result.

Where the autofocusing is unconditional, just use the [HTML autofocus attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus) instead of JS.

This removes all usage of the `$OnLoad` global, so we remove that functionality.