### PR TITLE
Password Storage Improvements

### DIFF
--- a/include/constants.php
+++ b/include/constants.php
@@ -193,3 +193,10 @@ const SEARCH_SELECT_FIELD = '
          P.uses  ';
 
 const LOGIN_QUERY = 'LOGIN';
+
+# passed to pgcrypto gen_salt when creating or updating user passwords in the database
+# used by
+# www/new-user.php
+# www/customize.php
+define('PW_HASH_METHOD', 'md5');
+define('PW_HASH_COST', 0);

--- a/include/constants.php
+++ b/include/constants.php
@@ -198,5 +198,5 @@ const LOGIN_QUERY = 'LOGIN';
 # used by
 # www/new-user.php
 # www/customize.php
-define('PW_HASH_METHOD', 'md5');
-define('PW_HASH_COST', 0);
+define('PW_HASH_METHOD', 'bf');
+define('PW_HASH_COST', 14);

--- a/include/constants.php
+++ b/include/constants.php
@@ -192,11 +192,11 @@ const SEARCH_SELECT_FIELD = '
          Cl.svn_revision,
          P.uses  ';
 
-const LOGIN_QUERY = 'LOGIN';
 
 # passed to pgcrypto gen_salt when creating or updating user passwords in the database
 # used by
 # www/new-user.php
 # www/customize.php
-define('PW_HASH_METHOD', 'bf');
-define('PW_HASH_COST', 14);
+const HASH_UPDATE_QUERY = 'HASH_UPDATE';
+const PW_HASH_METHOD = 'bf';
+const PW_HASH_COST = 14;

--- a/include/constants.php
+++ b/include/constants.php
@@ -198,5 +198,5 @@ const SEARCH_SELECT_FIELD = '
 # www/new-user.php
 # www/customize.php
 const HASH_UPDATE_QUERY = 'HASH_UPDATE';
-const PW_HASH_METHOD = 'bf';
-const PW_HASH_COST = 14;
+if (!defined('PW_HASH_METHOD')) define('PW_HASH_METHOD', 'bf');
+if (!defined('PW_HASH_COST')) define('PW_HASH_COST', 14);

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -2340,15 +2340,16 @@ function BranchSuffix($Branch = BRANCH_HEAD) {
 
 function getLoginDetails($db, $statementName, $UserID, $Password) {
 
-   $sql = 'select * from users where lower(name) = lower($1) and password_hash = crypt($2, password_hash)';
-    if ($Debug || 0) {
-      echo '<pre>' . htmlentities($sql) . '<pre>';
-   }
+  $sql = 'select *, password_hash not like \'$2_$' . PW_HASH_COST . '$%\' as insecure_hash ' .
+    'from users where lower(name) = lower($1) and password_hash = crypt($2, password_hash)';
+  if ($Debug || 0) {
+    echo '<pre>' . htmlentities($sql) . '<pre>';
+  }
 
-   $result = pg_prepare($db, $statementName, $sql) or die('query failed ' . pg_errormessage());
-   if ($result) {
-      $result = pg_execute($db, $statementName, array($UserID, $Password))  or die('query failed ' . pg_errormessage());
-   }
+  $result = pg_prepare($db, $statementName, $sql) or die('query failed ' . pg_errormessage());
+  if ($result) {
+    $result = pg_execute($db, $statementName, array($UserID, $Password))  or die('query failed ' . pg_errormessage());
+  }
 
-   return $result;
+  return $result;
 }

--- a/www/customize.php
+++ b/www/customize.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -85,7 +86,7 @@ if (IsSet($submit)) {
 	}
 
 	# if no errors so far, and all three password fields are populated
-	if ($OK && $Password && $Password1 && $Password) {
+	if ($OK && $Password && $Password1 && $Password2) {
 		$result = getLoginDetails($db, LOGIN_QUERY, $User->name, $Password);
 		# there must be only 1 row in there.
 		if (pg_numrows($result) != 1) {
@@ -114,7 +115,8 @@ UPDATE users
 			}
 
 			if ($Password1 != '') {
-				$sql .= ", password_hash = crypt('" . 	pg_escape_string($Password1) . "', gen_salt('md5'))";
+				$sql .= ", password_hash = crypt('" . pg_escape_string($Password1) . "'";
+				$sql .= ", gen_salt('" . PW_HASH_METHOD . "', " . PW_HASH_COST ."))";
 			}
 
 			$sql .= " where cookie = '$visitor'";

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -131,7 +131,8 @@ if (IsSet($submit)) {
 						"watch_notice_id, emailsitenotices_yn, type, ip_address, number_of_days, password_hash) values (";
 				$sql .= pg_escape_string($UserID) . ", '" . pg_escape_string($UserLogin) . "', 'nocookie', '" . 
 					pg_escape_string($email) . "', '1', 'N', 'U', '" . pg_escape_string($_SERVER["REMOTE_ADDR"]) . "', " .
-					pg_escape_string($numberofdays) . ", crypt('" . pg_escape_string($Password1) . "' , gen_salt('md5')))";
+					pg_escape_string($numberofdays) . ", " .
+					"crypt('" . pg_escape_string($Password1) . "' , gen_salt('" . PW_HASH_METHOD ."', " . PW_HASH_COST .")))";
 
 				syslog(LOG_ERR, "FreshPorts new user: '$UserID', '$UserLogin', '$email', " . $_SERVER["REMOTE_ADDR"]);
 


### PR DESCRIPTION
This makes password hashing configurable via `constants.php`, then switches that config to using bcrypt for password hash storage rather than md5 for new users and users updating their passwords. bcrypt isn't perfect but is a significant improvement for no additional dependencies.

The cost may need tweaking depending on the DB server's hardware/load.