### PR TITLE
Cookie Attribute Updates

### DIFF
--- a/classes/user.php
+++ b/classes/user.php
@@ -200,7 +200,8 @@ class User {
 	}
 
 	function createUserToken() {
-		return hash('sha256', uniqid(rand(), true));
+		$token = hash('sha256', uniqid(random_int(0, getrandmax()), true))
+		return $token;
 	}
 
 }

--- a/include/constants.php
+++ b/include/constants.php
@@ -38,6 +38,7 @@ $UserStatusUnconfirmed = "U";
 
 $ProblemSolverEmailAddress	= "webmaster@freshports.org";
 
+if (!defined('USER_COOKIE_NAME')) define('USER_COOKIE_NAME', "visitor");
 
 #
 # SEQUENCES

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -731,7 +731,13 @@ function freshports_MoreCommitMsgToShow($message_id, $NumberOfLinesShown) {
 }
 
 function freshports_CookieClear() {
-	SetCookie(USER_COOKIE_NAME, '', 0, '/');
+	SetCookie(USER_COOKIE_NAME, '', array(
+		'expires' => 1, // 0 makes it a session cookie, we actually want it to delete soon
+		'path' => '/',
+		'secure' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'),
+		'httponly' => TRUE,
+		'samesite' => 'Lax',
+	));
 }
 
 function freshportsObscureHTML($email) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -731,7 +731,7 @@ function freshports_MoreCommitMsgToShow($message_id, $NumberOfLinesShown) {
 }
 
 function freshports_CookieClear() {
-	SetCookie("visitor", '', 0, '/');
+	SetCookie(USER_COOKIE_NAME, '', 0, '/');
 }
 
 function freshportsObscureHTML($email) {
@@ -1803,8 +1803,8 @@ function freshports_SideBar() {
 
          <td NOWRAP>';
 
-	if (IsSet($_COOKIE["visitor"])) {
-		$visitor = $_COOKIE["visitor"];
+	if (IsSet($_COOKIE[USER_COOKIE_NAME])) {
+		$visitor = $_COOKIE[USER_COOKIE_NAME];
 	}
 
 	if (IsSet($visitor)) {

--- a/include/getvalues.php
+++ b/include/getvalues.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/user.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	
 GLOBAL $User;
 $User = new User($db);
@@ -60,8 +61,8 @@ $User->id	= 0;
 // This is used to determine whether or not the cach can be used.
 $DefaultMaxArticles = $MaxArticles;
 
-if (IsSet($_COOKIE["visitor"])) {
-	$visitor = $_COOKIE["visitor"];
+if (IsSet($_COOKIE[USER_COOKIE_NAME])) {
+	$visitor = $_COOKIE[USER_COOKIE_NAME];
 }
 if (!empty($visitor)) {
 	

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -17,7 +18,7 @@
 
 $origin		= isset($_REQUEST['origin']) ? $_REQUEST['origin'] : null;
 $submit 	= isset($_REQUEST['submit']) ? $_REQUEST['submit'] : null;
-$visitor	= isset($_COOKIE['visitor']) ? $_COOKIE['visitor'] : null;
+$visitor	= isset($_COOKIE[USER_COOKIE_NAME]) ? $_COOKIE[USER_COOKIE_NAME] : null;
 
 if ($origin == '/index.php' || $origin == '') {
 	$origin = '/';

--- a/www/bouncing.php
+++ b/www/bouncing.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -17,7 +18,7 @@
 	$Debug = 0;
 
 	$submit		= $_POST["submit"];
-	$visitor	= $_COOKIE["visitor"];
+	$visitor	= $_COOKIE[USER_COOKIE_NAME];
 
 if ($submit) {
    $sql = "update users set emailbouncecount = 0 where cookie = '" . pg_escape_string($visitor) . "'";

--- a/www/customize.php
+++ b/www/customize.php
@@ -22,7 +22,7 @@
 	$AccountModified = 0;
 
 if (IsSet($_REQUEST['submit'])) $submit = $_REQUEST['submit'];
-$visitor = pg_escape_string($_COOKIE['visitor']);
+$visitor = pg_escape_string($_COOKIE[USER_COOKIE_NAME]);
 
 // if we don't know who they are, we'll make sure they login first
 if (!$visitor) {

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -21,7 +22,7 @@
 	$AccountModified = 0;
 
 if (IsSet($_REQUEST['submit'])) $submit = $_REQUEST['submit'];
-$visitor	= pg_escape_string($_COOKIE['visitor']);
+$visitor	= pg_escape_string($_COOKIE[USER_COOKIE_NAME]);
 
 // if we don't know who they are, we'll make sure they login first
 if (!$visitor) {

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -86,7 +87,7 @@ $Debug = 0;
 
 if ($Debug) # phpinfo();
 
-$visitor = $_COOKIE["visitor"];
+$visitor = $_COOKIE[USER_COOKIE_NAME];
 
 if ($_REQUEST['wlid']) {
 		# they clicked on the GO button and we have to apply the 

--- a/www/login.php
+++ b/www/login.php
@@ -71,7 +71,16 @@ if (IsSet($_REQUEST['LOGIN']) && $_REQUEST['UserID']) {
 				# if we were doing this in a user object, we could retry when there was a cookie collision and we get a unique index error
 				$result = pg_exec($db, $sql) or die('query failed ' . pg_errormessage());
 
-				SetCookie(USER_COOKIE_NAME, $Cookie, time() + 60*60*24*120, '/');
+				SetCookie(USER_COOKIE_NAME, $Cookie, array(
+					'expires' => time() + 60*60*24*120,
+					'path' => '/',
+					'secure' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off'),
+					'httponly' => TRUE,
+					// it's probably common for users to navigate from other sites like portscout
+					// we want them to still be logged in if that's the case
+					'samesite' => 'Lax',
+				));
+
 				header("Location: /");
 				// Make sure that code below does not get executed when we redirect.
 				exit;

--- a/www/login.php
+++ b/www/login.php
@@ -71,7 +71,7 @@ if (IsSet($_REQUEST['LOGIN']) && $_REQUEST['UserID']) {
 				# if we were doing this in a user object, we could retry when there was a cookie collision and we get a unique index error
 				$result = pg_exec($db, $sql) or die('query failed ' . pg_errormessage());
 
-				SetCookie("visitor", $Cookie, time() + 60*60*24*120, '/');
+				SetCookie(USER_COOKIE_NAME, $Cookie, time() + 60*60*24*120, '/');
 				header("Location: /");
 				// Make sure that code below does not get executed when we redirect.
 				exit;

--- a/www/logout.php
+++ b/www/logout.php
@@ -5,6 +5,7 @@
 	# Copyright (c) 1998-2003 DVL Software Limited
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 
@@ -13,15 +14,13 @@
 
 	freshports_CookieClear();
 
-        if (IsSet($_COOKIE["visitor"])) {
-                $visitor = $_COOKIE["visitor"];
+	if (IsSet($_COOKIE[USER_COOKIE_NAME])) {
+		$visitor = $_COOKIE[USER_COOKIE_NAME];
 
-                $sql = "UPDATE users SET cookie = 'nocookie' WHERE cookie = '" . pg_escape_string($_COOKIE["visitor"]) . "'";
-#                echo $sql;
+		$sql = "UPDATE users SET cookie = 'nocookie' WHERE cookie = '" . pg_escape_string($_COOKIE[USER_COOKIE_NAME]) . "'";
+		#echo $sql;
 		$result = pg_exec($db, $sql);
-		if (!$result) {
-                }
-        }
+	}
 
 	if (IsSet($_GET['origin'])) {
 		$origin = $_GET['origin'];

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 
@@ -253,7 +254,7 @@ function ChooseWatchLists($UserID, $db) {
 #	if ($Debug) phpinfo();
 
 	# you can only be here if you are logged in!
-	$visitor = $_COOKIE["visitor"];
+	$visitor = $_COOKIE[USER_COOKIE_NAME];
 	if (!$visitor) {
 		?>
 		<P>

--- a/www/port-watch.php
+++ b/www/port-watch.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -26,7 +27,7 @@
 	if (IsSet($_POST['submit'])) {
 		$submit = pg_escape_string($_POST['submit']);
 	}
-	$visitor = $_COOKIE['visitor'];
+	$visitor = $_COOKIE[USER_COOKIE_NAME];
 
 // if we don't know who they are, we'll make sure they login first
 if (!$visitor) {

--- a/www/ports-new.php
+++ b/www/ports-new.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -82,7 +83,7 @@ These are the recently added ports.
 </TD></TR>
 <?
 
-	$visitor = pg_escape_string($_COOKIE["visitor"]);
+	$visitor = pg_escape_string($_COOKIE[USER_COOKIE_NAME]);
 	if (IsSet($_GET["sort"])) {
 		$sort = pg_escape_string($_GET["sort"]);
 	} else {

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -5,16 +5,17 @@
 	# Copyright (c) 1998-2006 DVL Software Limited
 	#
 
-	if (!$_COOKIE['visitor']) {
-		header('Location: /login.php');  /* Redirect browser to PHP web site */
-		exit;  /* Make sure that code below does not get executed when we redirect. */
-	}
-
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
+
+	if (!$_COOKIE[USER_COOKIE_NAME]) {
+		header('Location: /login.php');  /* Redirect browser to PHP web site */
+		exit;  /* Make sure that code below does not get executed when we redirect. */
+	}
 
 	if (IN_MAINTENCE_MODE) {
                 header('Location: /' . MAINTENANCE_PAGE, TRUE, 307);

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -32,7 +33,7 @@ $Debug = 0;
 
 if ($Debug) # phpinfo();
 
-$visitor = $_COOKIE["visitor"];
+$visitor = $_COOKIE[USER_COOKIE_NAME];
 
 if ($_REQUEST['wlid']) {
 		# they clicked on the GO button and we have to apply the 

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -15,7 +16,7 @@
                 header('Location: /' . MAINTENANCE_PAGE, TRUE, 307);
 	}
 
-$visitor = $_COOKIE['visitor'];
+$visitor = $_COOKIE[USER_COOKIE_NAME];
 
 unset($add_name);
 unset($rename_name);

--- a/www/watch.php
+++ b/www/watch.php
@@ -6,6 +6,7 @@
 	#
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/common.php');
+	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/constants.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/freshports.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/databaselogin.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
@@ -25,7 +26,7 @@
 
 #	if ($Debug) phpinfo();
 
-	$visitor = $_COOKIE['visitor'];
+	$visitor = $_COOKIE[USER_COOKIE_NAME];
 
 	$IncludeUpdating              = IsSet($_REQUEST['updating']);
 	$OnlyThoseWithUpdatingEntries = IsSet($_REQUEST['updatingonly']);


### PR DESCRIPTION
Per mention in #249, some updates to how the user ID cookie is handled.

I considered switching to a hmac-signed value or something for token generation, but since we don't store actual data in the token I don't think it would be much of an improvement in security beyond just being an even longer value to guess. So I've just made it use a better source of entropy to theoretically make it harder to guess. I'm not an expert in security but I think what we have is actually OK.

FreshPorts doesn't access the cookie from JS anywhere I can see, so it's made HTTPOnly to reduce the risk from XSS attacks accessing user tokens. If the site is served over HTTPS I've made it so the cookies are only sent in that way going forward. I've set the samesite attribute explicitly to the modern default, `Lax` instead of `Strict` because I think a fair portion of users probably click through from other systems and not being logged in in that case without a refresh might be confusing. Also the site is probably better off with an actual CSRF audit anyway, rather than relying on a cookie setting protecting users.

I've also made the cookie name configurable.

TODO:
- CSRF checks for forms that update DB state
- Review interactions with the cookie in the database queries