### PR TITLE
Header Cleanup

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -886,7 +886,6 @@ function freshports_HEAD_charset() {
 function freshports_HEAD_main_items() {
 	return '
 	<LINK REL="SHORTCUT ICON" HREF="/favicon.ico">
-	<meta name="MSSmartTagsPreventParsing" content="TRUE">
 
 	<link rel="alternate" type="application/rss+xml" title="FreshPorts - The Place For Ports" href="https://' . $_SERVER['HTTP_HOST'] . '/backend/rss2.0.php">
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -846,7 +846,7 @@ GLOBAL $FreshPortsLogoHeight;
 ";
 	}
 
-    $HTML .= '<span class="amazon">As an Amazon Associate I earn from qualifying purchases.<br>Want a good read? Try <a target="_blank" rel="noopener noreferrer" href="https://www.amazon.com/gp/product/B07PVTBWX7/ref=as_li_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=B07PVTBWX7&amp;linkCode=as2&amp;tag=thfrdi0c-20&amp;linkId=f4cffa799f323b5adebf953c7d3f20ea">FreeBSD Mastery: Jails (IT Mastery Book 15)</a><img src="//ir-na.amazon-adsystem.com/e/ir?t=thfrdi0c-20&amp;l=am2&amp;o=1&amp;a=B07PVTBWX7" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;"></span>';
+    $HTML .= '<span class="amazon">As an Amazon Associate I earn from qualifying purchases.<br>Want a good read? Try <a target="_blank" rel="noopener noreferrer" href="https://www.amazon.com/gp/product/B07PVTBWX7/ref=as_li_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=B07PVTBWX7&amp;linkCode=as2&amp;tag=thfrdi0c-20&amp;linkId=f4cffa799f323b5adebf953c7d3f20ea">FreeBSD Mastery: Jails (IT Mastery Book 15)</a><img src="//ir-ca.amazon-adsystem.com/e/ir?t=thfrdi0c-20&amp;l=am2&amp;o=1&amp;a=B07PVTBWX7" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;"></span>';
 	
 	$HTML .= '</td>';
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -965,39 +965,7 @@ function freshports_Header($ArticleTitle, $Description, $Keywords, $Phorum=0) {
 }
 
 function freshports_style($Phorum=0) {
-
 	echo '	<link rel="stylesheet" href="/css/freshports.css" type="text/css">' . "\n";
-
-	# from https://www.w3schools.com/css/css_tooltip.asp
-	# initially planned for Quarterly branch information: https://github.com/FreshPorts/freshports/issues/115
-	echo '<style type="text/css">
-.tooltip {
-  position: relative;
-  display: inline-block;
-  border-bottom: 1px dotted black;
-}
-
-.tooltip .tooltiptext {
-  visibility: hidden;
-  width: 120px;
-  background-color: black;
-  color: #fff;
-  text-align: center;
-  border-radius: 6px;
-  padding: 5px 0;
-  
-  /* Position the tooltip */
-  position: absolute;
-  z-index: 1;
-  top: -5px;
-  left: 105%;
-}
-
-.tooltip:hover .tooltiptext {
-  visibility: visible;
-}
-</style>';
-
 }
 
 function freshports_body($ExtraScript = null) {

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -187,7 +187,7 @@ li.extraspace {
 .packages td, .packages th { padding:8px; border:1px solid #000; }
 
 
-# for horizontal scrolling of package tables - re https://www.w3schools.com/howto/howto_css_menu_horizontal_scroll.asp#contact
+/* for horizontal scrolling of package tables - re https://www.w3schools.com/howto/howto_css_menu_horizontal_scroll.asp#contact */
 
 div.scrollmenu {
   background-color: #333;
@@ -206,6 +206,35 @@ td.version:hover {
 }
 
 
+/*
+  from https://www.w3schools.com/css/css_tooltip.asp
+  1initially planned for Quarterly branch information: https://github.com/FreshPorts/freshports/issues/115
+*/
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  top: -5px;
+  left: 105%;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
 
   
   

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -1,5 +1,12 @@
 {
- "name": "App",
+ "name": "FreshPorts",
+ "description": "FreshPorts has everything you want to know about FreeBSD software, ports, packages, applications, whatever term you want to use.",
+ "categories": ["utilities", "security", "news"],
+ "lang": "en",
+ "start_url": "/",
+ "display": "browser",
+ "background_color": "#FFFFFF",
+ "theme_color": "#FFFFFF",
  "icons": [
   {
    "src": "\/images\/android-icon-36x36.png",


### PR DESCRIPTION
Some minor cleanups in the <head> tag and site header.

- Remove the MSSmartTags header: I don't think this does anything relevant any more, the references I find to it only are for an unreleased Internet Explorer 6 feature?
- Move the tooltip styles into the global site CSS file (and fix some comment syntax while I'm there)
- The Amazon associate pixel seems to not actually have a valid cert for the `ir-na.amazon-adsystem.com` domain, so I've updated it to `ir-ca.amazon-adsystem.com` for which the cert is valid.
- Not sure if it's used much, but added some more details to the `manifest.json` file for those that want to add FreshPorts to their mobile device homescreen or install it as a PWA.