### PR TITLE
HTML Cleanup: table[border], a > img[border], table[cellspacing], [bgcolor]

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -145,7 +145,7 @@ class DisplayCommit {
 				$MaxNumberPortsToShow      = 10;
 
 				if ($mycommit->commit_date != $PreviousCommit->commit_date) {
-					$this->HTML .= '<TR><TD COLSPAN="3" BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="0">' . "\n";
+					$this->HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
 					$this->HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
 					$this->HTML .= '</TD></TR>' . "\n\n";
 				}

--- a/classes/files-display.php
+++ b/classes/files-display.php
@@ -43,7 +43,7 @@ class FilesDisplay {
 		}
 
 		$this->HTML .= '
-<table border="1" width="100%" CELLSPACING="0" CELLPADDING="5">
+<table class="fullwidth bordered" CELLPADDING="5">
 <TR>
 ';
 		switch ($NumRows) {

--- a/include/ads-burst-media.php
+++ b/include/ads-burst-media.php
@@ -32,7 +32,7 @@ function Ad_PhpPgAdsBase($Zone, $N) {
       document.write ("&amp;referer=" + escape(document.referrer));
    document.write ("\'><" + "/script>");
 //-->
-</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_top\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $N . '\' border=\'0\' alt=\'\'></a></noscript>
+</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_top\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $N . '\' alt=\'\'></a></noscript>
 ';
 }
 
@@ -44,7 +44,7 @@ rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/v=2.1S/sz=125x125A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
 </script><noscript><a href="http://www.burstnet.com/ads/cb4556a-map.cgi/ns/v=2.1S/sz=125x125A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/ns/v=2.1S/sz=125x125A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/ns/v=2.1S/sz=125x125A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 ';
@@ -60,7 +60,7 @@ if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.1S/sz=468x60A/\'+rnum+\'/NI/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
 
 </script><noscript><a href="http://www.burstnet.com/ads/ad4556a-map.cgi/ns/v=2.1S/sz=468x60A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=468x60A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=468x60A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
   ';
@@ -76,7 +76,7 @@ if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.1S/sz=468x60A|728x90A/\'+rnum+\'/NI/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
 
 </script><noscript><a href="http://www.burstnet.com/ads/ad4556a-map.cgi/ns/v=2.1S/sz=468x60A|728x90A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=468x60A|728x90A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=468x60A|728x90A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
   ';
@@ -102,7 +102,7 @@ rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.1S/sz=120x600A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
 </script><noscript><a href="http://www.burstnet.com/ads/sk4556a-map.cgi/ns/v=2.1S/sz=120x600A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.1S/sz=120x600A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.1S/sz=120x600A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
   ';
@@ -116,7 +116,7 @@ function Ad_160x600() {
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.1S/sz=120x600A|160x600A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
   </script><noscript><a href="http://www.burstnet.com/ads/sk4556a-map.cgi/ns/v=2.1S/sz=120x600A|160x600A/" target="_top">
-  <img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.1S/sz=120x600A|160x600A/" border="0" alt="Click Here"></a>
+  <img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.1S/sz=120x600A|160x600A/" alt="Click Here"></a>
   </noscript>
   <!-- END BURST CODE -->
   
@@ -131,7 +131,7 @@ function Ad_468x60_Below() {
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/v=2.1S/sz=468x60B/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
   </script><noscript><a href="http://www.burstnet.com/ads/ba4556a-map.cgi/ns/v=2.1S/sz=468x60B/" target="_top">
-  <img src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/ns/v=2.1S/sz=468x60B/" border="0" alt="Click Here"></a>
+  <img src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/ns/v=2.1S/sz=468x60B/" alt="Click Here"></a>
   </noscript>
   <!-- END BURST CODE -->
   
@@ -146,7 +146,7 @@ function Ad_300x250() {
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.1S/sz=300x250A/NZ/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
   </script><noscript><a href="http://www.burstnet.com/ads/ad4556a-map.cgi/ns/v=2.1S/sz=300x250A/" target="_top">
-  <img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=300x250A/" border="0" alt="Click Here"></a>
+  <img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.1S/sz=300x250A/" alt="Click Here"></a>
   </noscript>
   <!-- END BURST CODE -->
   ';

--- a/include/ads-google-adsense.php
+++ b/include/ads-google-adsense.php
@@ -34,7 +34,7 @@ function Ad_PhpPgAdsBase($Zone, $N) {
       document.write ("&amp;referer=" + escape(document.referrer));
    document.write ("\'><" + "/script>");
 //-->
-</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_top\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $N . '\' border=\'0\' alt=\'\'></a></noscript>
+</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_top\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $N . '\' alt=\'\'></a></noscript>
 ';
 }
 

--- a/include/ads-phppgads.php
+++ b/include/ads-phppgads.php
@@ -24,7 +24,7 @@ function Ad_PhpPgAdsBase($Zone, $N) {
       document.write ("&amp;referer=" + escape(document.referrer));
    document.write ("\'><" + "/script>");
 //-->
-</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_blank\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $Zone . '\' border=\'0\' alt=\'\'></a></noscript>
+</script><noscript><a href=\'http://ads.unixathome.org/phpPgAds/adclick.php?n=' . $N . '\' target=\'_blank\'><img src=\'http://ads.unixathome.org/phpPgAds/adview.php?what=zone:' . $Zone . '&amp;n=' . $Zone . '\' alt=\'\'></a></noscript>
 
 	';
 	

--- a/include/burstmedia.php
+++ b/include/burstmedia.php
@@ -21,7 +21,7 @@ document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ad4556a.c
 
 </script>
 <noscript><a href="http://www.burstnet.com/ads/ad4556a-map.cgi/ns/v=2.0S/sz=468x60A|728x90A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.0S/sz=468x60A|728x90A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.0S/sz=468x60A|728x90A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 
@@ -39,7 +39,7 @@ rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.0S/sz=120x600A|160x600A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
 <noscript><a href="http://www.burstnet.com/ads/sk4556a-map.cgi/ns/v=2.0S/sz=120x600A|160x600A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.0S/sz=120x600A|160x600A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/ns/v=2.0S/sz=120x600A|160x600A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 
@@ -60,7 +60,7 @@ rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/v=2.0S/sz=125x125A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
 <noscript><a href="http://www.burstnet.com/ads/cb4556a-map.cgi/ns/v=2.0S/sz=125x125A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/ns/v=2.0S/sz=125x125A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/ns/v=2.0S/sz=125x125A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 
@@ -77,7 +77,7 @@ rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/v=2.0S/sz=468x60B/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
 <noscript><a href="http://www.burstnet.com/ads/ba4556a-map.cgi/ns/v=2.0S/sz=468x60B/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/ns/v=2.0S/sz=468x60B/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/ns/v=2.0S/sz=468x60B/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 
@@ -97,7 +97,7 @@ rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.0S/sz=300x250A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
 <noscript><a href="http://www.burstnet.com/ads/ad4556a-map.cgi/ns/v=2.0S/sz=300x250A/" target="_top">
-<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.0S/sz=300x250A/" border="0" alt="Click Here"></a>
+<img src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/ns/v=2.0S/sz=300x250A/" alt="Click Here"></a>
 </noscript>
 <!-- END BURST CODE -->
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -27,8 +27,6 @@ DEFINE('BORDER',                'bordered');
 
 DEFINE('UNMAINTAINTED_ADDRESS', 'ports@freebsd.org');
 
-DEFINE('BACKGROUND_COLOUR', '#8c0707');
-
 DEFINE('CLICKTOADD', 'Click to add this to your default watch list[s]');
 
 DEFINE('SPONSORS', 'Servers and bandwidth provided by<br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_new">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_new">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_new">RootBSD</a>');

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -336,43 +336,43 @@ return '
 }
 
 function freshports_Fallout_Icon() {
-	return '<img src="/images/fallout-16x16.png" alt="pkg-fallout" title="pkg-fallout" border="0" width="16" height="16" vspace="1">';
+	return '<img src="/images/fallout-16x16.png" alt="pkg-fallout" title="pkg-fallout" width="16" height="16" vspace="1">';
 }
 
 function freshports_Subversion_Icon($Title = 'Subversion') {
-	return '<img src="/images/subversion.jpg" alt="' . $Title . '" title="' . $Title . '" border="0" width="16" height="16" vspace="1">';
+	return '<img src="/images/subversion.jpg" alt="' . $Title . '" title="' . $Title . '" width="16" height="16" vspace="1">';
 }
 
 function freshports_Git_Icon($Title = 'git') {
-	return '<img src="/images/git.png" alt="' . $Title . '" title="' . $Title . '" border="0" width="22" height="22" vspace="1">';
+	return '<img src="/images/git.png" alt="' . $Title . '" title="' . $Title . '" width="22" height="22" vspace="1">';
 }
 
 function freshports_SanityTestFailure_Icon($Title = 'Sanity Test Failure') {
-	return '<img src="/images/stf.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="13" height="13" vspace="1">';
+	return '<img src="/images/stf.gif" alt="' . $Title . '" title="' . $Title . '" width="13" height="13" vspace="1">';
 }
 
 function freshports_Ascending_Icon($Title = 'Ascending Order') {
-	return '<img src="/images/ascending.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="9" height="9" align="middle">';
+	return '<img src="/images/ascending.gif" alt="' . $Title . '" title="' . $Title . '" width="9" height="9" align="middle">';
 }
 
 function freshports_Descending_Icon($Title = 'Descending Order') {
-	return '<img src="/images/descending.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="9" height="9" align="middle">';
+	return '<img src="/images/descending.gif" alt="' . $Title . '" title="' . $Title . '" width="9" height="9" align="middle">';
 }
 
 function freshports_Search_Icon($Title = 'Search') {
-	return '<img src="/images/search.jpg" alt="' . $Title . '" title="' . $Title . '" border="0" width="17" height="17" align="top">';
+	return '<img src="/images/search.jpg" alt="' . $Title . '" title="' . $Title . '" width="17" height="17" align="top">';
 }
 
 function freshports_Bugs_Find_Icon($Title = 'Find issues related to this port') {
-	return '<img src="/images/bug.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="16" height="16" align="top">';
+	return '<img src="/images/bug.gif" alt="' . $Title . '" title="' . $Title . '" width="16" height="16" align="top">';
 }
 
 function freshports_Bugs_Report_Icon($Title = 'Report an issue related to this port') {
-	return '<img src="/images/bug_report.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="16" height="16" align="top">';
+	return '<img src="/images/bug_report.gif" alt="' . $Title . '" title="' . $Title . '" width="16" height="16" align="top">';
 }
 
 function freshports_WatchListCount_Icon() {
-	return '<img src="/images/sum.gif" alt="on this many watch lists" title="on this many watch lists" border="0" width="8" height="11">';
+	return '<img src="/images/sum.gif" alt="on this many watch lists" title="on this many watch lists" width="8" height="11">';
 }
 
 function freshports_WatchListCount_Icon_Link() {
@@ -380,11 +380,11 @@ function freshports_WatchListCount_Icon_Link() {
 }
 
 function freshports_Files_Icon() {
-	return '<img src="/images/logs.gif" alt="files touched by this commit" title="files touched by this commit" border="0" width="17" height="20">';
+	return '<img src="/images/logs.gif" alt="files touched by this commit" title="files touched by this commit" width="17" height="20">';
 }
 
 function freshports_Refresh_Icon() {
-	return '<img src="/images/refresh.gif" alt="Refresh" title="Refresh - this port is being refreshed, or make failed to run error-free." border="0" width="15" height="18">';
+	return '<img src="/images/refresh.gif" alt="Refresh" title="Refresh - this port is being refreshed, or make failed to run error-free." width="15" height="18">';
 }
 
 function freshports_Refresh_Icon_Link() {
@@ -392,7 +392,7 @@ function freshports_Refresh_Icon_Link() {
 }
 
 function freshports_Deleted_Icon() {
-	return '<img src="/images/deleted.gif" alt="Deleted" title="Deleted" border="0" width="21" height="18">';
+	return '<img src="/images/deleted.gif" alt="Deleted" title="Deleted" width="21" height="18">';
 }
 
 function freshports_Deleted_Icon_Link() {
@@ -415,7 +415,7 @@ function freshports_Forbidden_Icon($HoverText = '') {
 	$Alt       = "Forbidden";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/forbidden.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="20" height="20">';
+	return '<img src="/images/forbidden.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="20">';
 }
 
 function freshports_Forbidden_Icon_Link($HoverText = '') {
@@ -426,7 +426,7 @@ function freshports_Broken_Icon($HoverText = '') {
 	$Alt       = "Broken";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/broken.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="17" height="16">';
+	return '<img src="/images/broken.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="17" height="16">';
 }
 
 function freshports_Broken_Icon_Link($HoverText = '') {
@@ -437,7 +437,7 @@ function freshports_Deprecated_Icon($HoverText = '') {
 	$Alt       = "Deprecated";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/deprecated.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="18" height="18">';
+	return '<img src="/images/deprecated.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="18" height="18">';
 }
 
 function freshports_Deprecated_Icon_Link($HoverText = '') {
@@ -448,7 +448,7 @@ function freshports_Expired_Icon($HoverText = '') {
 	$Alt       = "Expired";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/expired.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="16" height="16">';
+	return '<img src="/images/expired.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="16" height="16">';
 }
 
 function freshports_Expired_Icon_Link($HoverText = '') {
@@ -459,7 +459,7 @@ function freshports_Expiration_Icon($HoverText = '') {
 	$Alt       = "Expiration Date";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/expiration.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="16" height="16">';
+	return '<img src="/images/expiration.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="16" height="16">';
 }
 
 function freshports_Expiration_Icon_Link($HoverText = '') {
@@ -470,7 +470,7 @@ function freshports_Restricted_Icon($HoverText = '') {
 	$Alt       = "Restricted";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/restricted.jpg" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="16" height="16">';
+	return '<img src="/images/restricted.jpg" alt="' . $Alt . '" title="' . $HoverText . '" width="16" height="16">';
 }
 
 function freshports_Restricted_Icon_Link($HoverText = '') {
@@ -481,7 +481,7 @@ function freshports_Is_Interactive_Icon($HoverText = '') {
 	$Alt       = "Is Interactive";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/crt.gif" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="16" height="16" align="top">';
+	return '<img src="/images/crt.gif" alt="' . $Alt . '" title="' . $HoverText . '" width="16" height="16" align="top">';
 }
 
 function freshports_Is_Interactive_Icon_Link($HoverText = '') {
@@ -492,7 +492,7 @@ function freshports_No_CDROM_Icon($HoverText = '') {
 	$Alt       = "NO CDROM";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/no_cdrom.jpg" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="16" height="16">';
+	return '<img src="/images/no_cdrom.jpg" alt="' . $Alt . '" title="' . $HoverText . '" width="16" height="16">';
 }
 
 function freshports_No_CDROM_Icon_Link($HoverText = '') {
@@ -503,7 +503,7 @@ function freshports_Ignore_Icon($HoverText = '') {
 	$Alt       = "Ignore";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" border="0" width="20" height="21;">';
+	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="21;">';
 }
 
 function freshports_Ignore_Icon_Link($HoverText = '') {
@@ -511,35 +511,35 @@ function freshports_Ignore_Icon_Link($HoverText = '') {
 }
 
 function freshports_New_Icon() {
-	return '<img src="/images/new.gif" alt="new!" title="new!" border="0" width="28" height="11" HSPACE="2">';
+	return '<img src="/images/new.gif" alt="new!" title="new!" width="28" height="11" HSPACE="2">';
 }
 
 function freshports_Mail_Icon() {
-	return '<img src="/images/envelope10.gif" alt="Original commit" title="Original commit message" border="0" width="32" height="18">';
+	return '<img src="/images/envelope10.gif" alt="Original commit" title="Original commit message" width="32" height="18">';
 }
 
 function freshports_Commit_Icon() {
-	return '<img src="/images/copy.gif" alt="Commit details" title="FreshPorts commit message" border="0" width="16" height="16">';
+	return '<img src="/images/copy.gif" alt="Commit details" title="FreshPorts commit message" width="16" height="16">';
 }
 
 function freshports_CVS_Icon() {
-	return '<img src="/images/cvs.png" alt="CVS log" title="CVS log" border="0" width="19" height="17">';
+	return '<img src="/images/cvs.png" alt="CVS log" title="CVS log" width="19" height="17">';
 }
 
 function freshports_Watch_Icon() {
-	return '<img src="/images/watch-remove.gif" alt="Click to remove this from your default watch list[s]" title="Click to remove this from your default watch list[s]" border="0" width="16" height="16">';
+	return '<img src="/images/watch-remove.gif" alt="Click to remove this from your default watch list[s]" title="Click to remove this from your default watch list[s]" width="16" height="16">';
 }
 
 function freshports_Watch_Icon_Add() {
-	return '<img src="/images/watch-add.gif" alt="' . CLICKTOADD . '" title="' . CLICKTOADD . '" border="0" width="16" height="16">';
+	return '<img src="/images/watch-add.gif" alt="' . CLICKTOADD . '" title="' . CLICKTOADD . '" width="16" height="16">';
 }
 
 function freshports_Watch_Icon_Empty() {
-	return '<img src="/images/watch-empty.gif" alt="" title="" border="0" width="16" height="1">';
+	return '<img src="/images/watch-empty.gif" alt="" title="" width="16" height="1">';
 }
 
 function freshports_Encoding_Errors() {
-	return '<img src="/images/error.gif" alt="Encoding Errors (not all of the commit message was ASCII)" title="Encoding Errors (not all of the commit message was ASCII)" border="0" width="16" height="16">';
+	return '<img src="/images/error.gif" alt="Encoding Errors (not all of the commit message was ASCII)" title="Encoding Errors (not all of the commit message was ASCII)" width="16" height="16">';
 }
 
 function freshports_Encoding_Errors_Link() {
@@ -547,27 +547,27 @@ function freshports_Encoding_Errors_Link() {
 }
 
 function freshports_Repology_Icon() {
-	return '<img src="/images/repology.png" alt="View this port on Repology." title="View this port on Repology." border="0" width="16" height="16">';
+	return '<img src="/images/repology.png" alt="View this port on Repology." title="View this port on Repology." width="16" height="16">';
 }
 
 function freshports_VuXML_Icon() {
-	return '<img src="/images/vuxml.gif" alt="This port version is marked as vulnerable." title="This port version is marked as vulnerable." border="0" width="13" height="16">';
+	return '<img src="/images/vuxml.gif" alt="This port version is marked as vulnerable." title="This port version is marked as vulnerable." width="13" height="16">';
 }
 
 function freshports_VuXML_Icon_Faded() {
-	return '<img src="/images/vuxml-faded.gif" alt="An older version of this port was marked as vulnerable." title="An older version of this port was marked as vulnerable." border="0" width="13" height="16">';
+	return '<img src="/images/vuxml-faded.gif" alt="An older version of this port was marked as vulnerable." title="An older version of this port was marked as vulnerable." width="13" height="16">';
 }
 
 function freshports_Revision_Icon() {
-	return '<img src="/images/revision.jpg" alt="View revision" title="view revision" border="0" width="11" height="15" align="top">';
+	return '<img src="/images/revision.jpg" alt="View revision" title="view revision" width="11" height="15" align="top">';
 }
 
 function freshports_Annotate_Icon() {
-	return '<img src="/images/annotate.png" alt="Annotate / Blame" title="Annotate / Blame" border="0" width="20" height="20" align="middle">';
+	return '<img src="/images/annotate.png" alt="Annotate / Blame" title="Annotate / Blame" width="20" height="20" align="middle">';
 }
 
 function freshports_Diff_Icon() {
-	return '<img src="/images/diff.png" alt="View diff" title="view diff" border="0" width="15" height="11" align="top">';
+	return '<img src="/images/diff.png" alt="View diff" title="view diff" width="15" height="11" align="top">';
 }
 
 
@@ -643,11 +643,11 @@ function freshports_Email_Link($message_id) {
 }
 
 function freshports_Commit_Flagged_Icon($Title = 'Commit Flagged') {
-	return '<img src="/images/commit-flagged.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="16" height="16" align="middle">';
+	return '<img src="/images/commit-flagged.gif" alt="' . $Title . '" title="' . $Title . '" width="16" height="16" align="middle">';
 }
 
 function freshports_Commit_Flagged_Not_Icon($Title = 'Commit Not Flagged') {
-	return '<img src="/images/commit-flagged-not.gif" alt="' . $Title . '" title="' . $Title . '" border="0" width="16" height="16" align="middle">';
+	return '<img src="/images/commit-flagged-not.gif" alt="' . $Title . '" title="' . $Title . '" width="16" height="16" align="middle">';
 }
 
 function freshports_Commit_Flagged_Link($message_id) {
@@ -716,7 +716,7 @@ function freshports_Commit_Link_Port($MessageID, $Category, $Port) {
 
 function freshports_MorePortsToShow($message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow) {
 	$HTML  = "(Only the first $MaxNumberPortsToShow of $NumberOfPortsInThisCommit ports in this commit are shown above. ";
-	$HTML .= freshports_Commit_Link($message_id, '<img src="/images/play.gif" alt="View all ports for this commit" title="View all ports for this commit" border="0" width="13" height="13">');
+	$HTML .= freshports_Commit_Link($message_id, '<img src="/images/play.gif" alt="View all ports for this commit" title="View all ports for this commit" width="13" height="13">');
 	$HTML .= ")";
 
 	return $HTML;
@@ -724,7 +724,7 @@ function freshports_MorePortsToShow($message_id, $NumberOfPortsInThisCommit, $Ma
 
 function freshports_MoreCommitMsgToShow($message_id, $NumberOfLinesShown) {
 	$HTML  = "(Only the first $NumberOfLinesShown lines of the commit message are shown above ";
-	$HTML .= freshports_Commit_Link($message_id, '<img src="/images/play.gif" alt="View all of this commit message" title="View all of this commit message" border="0" width="13" height="13">');
+	$HTML .= freshports_Commit_Link($message_id, '<img src="/images/play.gif" alt="View all of this commit message" title="View all of this commit message" width="13" height="13">');
 	$HTML .= ")";
 
 	return $HTML;
@@ -829,7 +829,7 @@ GLOBAL $FreshPortsLogoHeight;
 	} else {
 		$HTML .= '/';
 	}
-	$HTML .= '"><img id="fp-logo" src="' . $FreshPortsLogo . '" alt="' . $FreshPortsName . ' -- ' . $FreshPortsSlogan . '" title="' . $FreshPortsName . ' -- ' . $FreshPortsSlogan . '" width="' . $FreshPortsLogoWidth . '" height="' . $FreshPortsLogoHeight . '" border="0"></a>
+	$HTML .= '"><img id="fp-logo" src="' . $FreshPortsLogo . '" alt="' . $FreshPortsName . ' -- ' . $FreshPortsSlogan . '" title="' . $FreshPortsName . ' -- ' . $FreshPortsSlogan . '" width="' . $FreshPortsLogoWidth . '" height="' . $FreshPortsLogoHeight . '"></a>
 ';
 
     if (defined('SHOW_ANIMATED_BUG') && SHOW_ANIMATED_BUG)
@@ -841,17 +841,17 @@ GLOBAL $FreshPortsLogoHeight;
     	$HTML .= "
 
 <!-- IPv6-test.com button BEGIN -->
-<a href='https://ipv6-test.com/validate.php?url=referer' rel='noopener noreferrer'><img src='/images/button-ipv6-big.png' alt='ipv6 ready' title='ipv6 ready' border='0'></a>
+<a href='https://ipv6-test.com/validate.php?url=referer' rel='noopener noreferrer'><img src='/images/button-ipv6-big.png' alt='ipv6 ready' title='ipv6 ready'></a>
 <!-- IPv6-test.com button END -->
 ";
 	}
 
-    $HTML .= '<span class="amazon">As an Amazon Associate I earn from qualifying purchases.<br>Want a good read? Try <a target="_blank" rel="noopener noreferrer" href="https://www.amazon.com/gp/product/B07PVTBWX7/ref=as_li_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=B07PVTBWX7&amp;linkCode=as2&amp;tag=thfrdi0c-20&amp;linkId=f4cffa799f323b5adebf953c7d3f20ea">FreeBSD Mastery: Jails (IT Mastery Book 15)</a><img src="//ir-na.amazon-adsystem.com/e/ir?t=thfrdi0c-20&amp;l=am2&amp;o=1&amp;a=B07PVTBWX7" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;"></span>';
+    $HTML .= '<span class="amazon">As an Amazon Associate I earn from qualifying purchases.<br>Want a good read? Try <a target="_blank" rel="noopener noreferrer" href="https://www.amazon.com/gp/product/B07PVTBWX7/ref=as_li_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=B07PVTBWX7&amp;linkCode=as2&amp;tag=thfrdi0c-20&amp;linkId=f4cffa799f323b5adebf953c7d3f20ea">FreeBSD Mastery: Jails (IT Mastery Book 15)</a><img src="//ir-na.amazon-adsystem.com/e/ir?t=thfrdi0c-20&amp;l=am2&amp;o=1&amp;a=B07PVTBWX7" width="1" height="1" alt="" style="border:none !important; margin:0px !important;"></span>';
 	
 	$HTML .= '</td>';
 
 if (date("M") == 'Nov' && date("j") <= 12) {
-	$HTML .= '	<td nowrap align="center" CLASS="sans" valign="bottom"><a href="https://www.google.ca/search?q=remembrance+day" rel="noopener noreferrer"><img src="/images/poppy.gif" width="50" height="48" border="0" alt="Remember" title="Remember"><br>I remember</a></td>';
+	$HTML .= '	<td nowrap align="center" CLASS="sans" valign="bottom"><a href="https://www.google.ca/search?q=remembrance+day" rel="noopener noreferrer"><img src="/images/poppy.gif" width="50" height="48" alt="Remember" title="Remember"><br>I remember</a></td>';
 } else {
 	$HTML .= '	<td>';
 	$HTML .= '<div id="followus"><div class="header">Follow us</div><a href="https://news.freshports.org/" rel="noopener noreferrer">Blog</a><br><a href="https://twitter.com/freshports/" rel="noopener noreferrer">Twitter</a><br><a href="https://freshports.wordpress.com/" rel="noopener noreferrer">Status page</a><br></div>';
@@ -1714,23 +1714,23 @@ function freshports_ShowFooter($PhorumBottom = 0) {
 <td align="center">
 
 <a href="https://www.freebsd.org/" rel="noopener noreferrer"><img src="/images/pbfbsd2.gif"
-alt="powered by FreeBSD" border="0" width="171" height="64"></a>
+alt="powered by FreeBSD" width="171" height="64"></a>
 
 &nbsp;
 
 <a href="https://www.php.net/" rel="noopener noreferrer"><img src="/images/php-med-trans-light.gif"
-alt="powered by php" border="0" width="95" height="50"></a>
+alt="powered by php" width="95" height="50"></a>
 &nbsp;
 
 <a href="https://www.postgresql.org/" rel="noopener noreferrer"><img src="/images/pg-power.jpg"
-alt="powered by PostgreSQL" border="0" width="164" height="59"></a>
+alt="powered by PostgreSQL" width="164" height="59"></a>
 
 
 </td></tr>
 <tr><td align="center">
 
 <a href="https://www.nginx.org/" rel="noopener noreferrer"><img src="/images/nginx.gif" 
-alt="powered by nginx" border="0" width="121" height="32"></a>
+alt="powered by nginx" width="121" height="32"></a>
 
 <HR>
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1742,7 +1742,7 @@ alt="powered by nginx" width="121" height="32"></a>
 
 	$HTML .= '
 <tr><td>
-<table class="fullwdith">
+<table class="fullwidth">
 <tr>
 <td align="left"  valign="top">
 <small>' . SPONSORS . '</small>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -964,7 +964,8 @@ function freshports_Header($ArticleTitle, $Description, $Keywords, $Phorum=0) {
 
 function freshports_style($Phorum=0) {
 
-	echo '	<link rel="stylesheet" href="/css/freshports.css" type="text/css">' . "\n";
+	$version = substr(hash_file('sha1', $_SERVER['DOCUMENT_ROOT'] . '/css/freshports.css'), 0, 8);
+	echo '	<link rel="stylesheet" href="/css/freshports.css?v=' . $version . '" type="text/css">' . "\n";
 
 	# from https://www.w3schools.com/css/css_tooltip.asp
 	# initially planned for Quarterly branch information: https://github.com/FreshPorts/freshports/issues/115

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -22,8 +22,8 @@ DEFINE('COPYRIGHTHOLDERURL',    'https://www.langille.org/');
 DEFINE('URL2LINK_CUTOFF_LEVEL', 0);
 DEFINE('FAQLINK',               'faq.php');
 DEFINE('PORTSMONURL',           'http://portsmon.freebsd.org/portoverview.py');
-DEFINE('NOBORDER',              '0');
-DEFINE('BORDER',                '1');
+DEFINE('NOBORDER',              'borderless');
+DEFINE('BORDER',                'bordered');
 
 DEFINE('UNMAINTAINTED_ADDRESS', 'ports@freebsd.org');
 
@@ -44,7 +44,7 @@ require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/watchnotice.php');
 function freshports_MainTable() {
 	GLOBAL $TableWidth;
 
-	return '<table width="' . $TableWidth . '" border="0">
+	return '<table width="' . $TableWidth . '" class="borderless">
 ';
 }
 
@@ -139,13 +139,13 @@ function freshports_Search_Committer($Committer) {
 	      freshports_Search_Icon('search for other commits by this committer') . '</a>';
 }
 
-function freshports_MainContentTable($Border=1, $ColSpan=1) {
-	return '<table width="100%" border="' . $Border . '" cellspacing="0" cellpadding="8">' . 
+function freshports_MainContentTable($Classes=BORDER, $ColSpan=1) {
+	return '<table class="fullwidth ' . $Classes . '" cellpadding="8">' . 
 		PortsFreezeStatus($ColSpan);
 }
 
 function  freshports_ErrorContentTable() {
-	echo '<table width="100%" border="1" align="center" cellpadding="1" cellspacing="0">
+	echo '<table class="fullwidth bordered" align="center" cellpadding="1">
 ';
 }
 
@@ -820,7 +820,7 @@ GLOBAL $FreshPortsLogoHeight;
 #echo "$LocalTimeAdjustment<br>";
 
 	$HTML = '<br>
-<table width="' . $TableWidth . '" border="0" align="center">
+<table width="' . $TableWidth . '" class="borderless" align="center">
 <tr>
 	<td><a href="';
 
@@ -1029,7 +1029,7 @@ if (!empty($ExtraScript)) {
 
 		if ($BannerAd == 1) echo 'banner is on';
 
-		echo '<table border="1">';
+		echo '<table class="bordered">';
 		echo '<tr><td>ShowAds</td><td>'               . $ShowAds               . '</td></tr>';
 		echo '<tr><td>BannerAd</td><td>'              . $BannerAd              . '</td></tr>';
 		echo '<tr><td>BannerAdUnder</td><td>'         . $BannerAdUnder         . '</td></tr>';
@@ -1248,7 +1248,7 @@ function freshports_PortCommitsHeader($port) {
 	
 	$HTML = '';
 
-	$HTML .= '<table border="1" width="100%" cellspacing="0" cellpadding="5">' . "\n";
+	$HTML .= '<table class="fullwidth bordered" cellpadding="5">' . "\n";
 	$HTML .= "<tr>\n";
 
 	$Columns = 3;
@@ -1692,7 +1692,7 @@ function freshports_ShowFooter($PhorumBottom = 0) {
 	GLOBAL $ShowPoweredBy;
 	GLOBAL $ShowAds;
 
-	$HTML = '<table width="' . $TableWidth . '" border="0" align="center">
+	$HTML = '<table width="' . $TableWidth . '" class="borderless" align="center">
 <tr><td>';
 
 
@@ -1704,7 +1704,7 @@ function freshports_ShowFooter($PhorumBottom = 0) {
 
 	$HTML .= '
 <HR>
-<table width="98%" border="0">
+<table width="98%" class="borderless">
 ';
 
 	if (IsSet($ShowPoweredBy)) {
@@ -1743,7 +1743,7 @@ alt="powered by nginx" width="121" height="32"></a>
 
 	$HTML .= '
 <tr><td>
-<table width="100%">
+<table class="fullwdith">
 <tr>
 <td align="left"  valign="top">
 <small>' . SPONSORS . '</small>
@@ -1795,7 +1795,7 @@ function freshports_SideBar() {
 	$ColumnWidth = 160;
 
 	$HTML = '
-  <table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+  <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
          <td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Login</b></big></FONT></td>
         </tr>
@@ -1844,7 +1844,7 @@ function freshports_SideBar() {
 </div>';
 
 	$HTML .= '	
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>This site</b></big></FONT></td>
 	</tr>
@@ -1863,7 +1863,7 @@ function freshports_SideBar() {
 	</tr>
 </table>
 <br>
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Search</b></big></FONT></td>
 	</tr>
@@ -1887,7 +1887,7 @@ function freshports_SideBar() {
 ';
 	if (file_exists(HTML_DIRECTORY . '/vuln-latest.html')) {
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Latest Vulnerabilities</b></big></FONT></td>
 	</tr>
@@ -1906,7 +1906,7 @@ $HTML .= '<br>
 
 	$HTML .= '
 
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Ports</b></big></FONT></td>
 	</tr>
@@ -1928,7 +1928,7 @@ if (IsSet($visitor)) {
 
 
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Watch Lists</b></big></FONT></td>
 	</tr>
@@ -1952,7 +1952,7 @@ $HTML .= '
 	GLOBAL $ShowAds;
 
 	if ($ShowAds) {
-		$HTML .= '<br><table border="0" cellpadding="5">
+		$HTML .= '<br><table class="borderless" cellpadding="5">
 		  <tr><td align="center">
 		';
 		$HTML .= Ad_160x600();
@@ -1963,7 +1963,7 @@ $HTML .= '
 
 	$HTML .= '<br>
 
-<table width="' . $ColumnWidth . '" border="1" cellspacing="0" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
 		<td COLSPAN="2" bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Statistics</b></big></FONT></td>
 	</tr>
@@ -2010,15 +2010,15 @@ function freshports_LinkToDate($Date, $Text = '', $BranchName = BRANCH_HEAD) {
 
 function freshports_ErrorMessage($Title, $ErrorMessage) {
 	$HTML = '
-<table width="100%" border="1" align="center" cellpadding="1" cellspacing="0" border="1">
+<table class="fullwidth bordered" align="center" cellpadding="1">
 <tr><td valign=TOP>
-<table width="100%">
+<table class="fullwidth">
 <tr>
 	' . freshports_PageBannerText($Title) . '
 </tr>
 <tr bgcolor="#ffffff">
 <td>
-  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <table class="fullwidth borderless" cellpadding="0">
   <tr valign=top>
    <td><img src="/images/warning.gif"></td>
    <td width="100%">
@@ -2043,7 +2043,7 @@ function DisplayAnnouncements($Announcement) {
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/htmlify.php');
 
 	$HTML = '';
-	$HTML .= '<table width="100%" cellpadding="4" cellspacing="0" border="0">' . "\n";
+	$HTML .= '<table class="fullwidth borderless" cellpadding="4">' . "\n";
 
 	$NumRows = $Announcement->NumRows();
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1630,7 +1630,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" bgcolor="' . BACKGROUND_COLOUR . '" height="29" COLSPAN="' . $ColSpan . '"><FONT COLOR="#FFFFFF"><big><big>' . $Text . '</big></big></FONT></td>' . "\n";
+	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><FONT COLOR="#FFFFFF"><big><big>' . $Text . '</big></big></FONT></td>' . "\n";
 }
 
 
@@ -1797,7 +1797,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Login</b></big></FONT></td>
+         <td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Login</b></big></FONT></td>
         </tr>
         <tr>
 
@@ -1846,7 +1846,7 @@ function freshports_SideBar() {
 	$HTML .= '	
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>This site</b></big></FONT></td>
+		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>This site</b></big></FONT></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1865,7 +1865,7 @@ function freshports_SideBar() {
 <br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Search</b></big></FONT></td>
+		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Search</b></big></FONT></td>
 	</tr>
 	<tr>
 
@@ -1889,7 +1889,7 @@ function freshports_SideBar() {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Latest Vulnerabilities</b></big></FONT></td>
+		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Latest Vulnerabilities</b></big></FONT></td>
 	</tr>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
@@ -1908,7 +1908,7 @@ $HTML .= '<br>
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Ports</b></big></FONT></td>
+		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Ports</b></big></FONT></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1930,7 +1930,7 @@ if (IsSet($visitor)) {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Watch Lists</b></big></FONT></td>
+		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Watch Lists</b></big></FONT></td>
 	</tr>
 	<tr>
 	<td valign="top">';
@@ -1965,7 +1965,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td COLSPAN="2" bgcolor="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><big><b>Statistics</b></big></FONT></td>
+		<td COLSPAN="2" class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Statistics</b></big></FONT></td>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -40,7 +40,8 @@ class freshports_page extends HTML_Page2 {
 		$this->setMetaData('robots', 'noarchive');
 		$this->setMetaData('robots', 'noindex');
 
-		$this->addStyleSheet('/css/freshports.css');
+		$version = substr(hash_file('sha1', $_SERVER['DOCUMENT_ROOT'] . '/css/freshports.css'), 0, 8);
+		$this->addStyleSheet('/css/freshports.css?v=' . $version);
 
 		$this->addFavicon('/favicon.ico');
 

--- a/include/new-user.php
+++ b/include/new-user.php
@@ -9,7 +9,7 @@
 ?>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" border="0" cellpadding="1">
+<TABLE width="*" class="borderless" cellpadding="1">
           <TR>
             <TD VALIGN="top">
 <?php if (IsSet($Customize)) { ?>

--- a/include/password-reset-via-token.php
+++ b/include/password-reset-via-token.php
@@ -11,7 +11,7 @@
 ?>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" border="0" cellpadding="1">
+<TABLE width="*" class="borderless" cellpadding="1">
           <TR>
             <TD VALIGN="top">
               <INPUT TYPE="hidden" NAME="token" VALUE="<?php echo $token ?>">

--- a/include/spam-filter-information.php
+++ b/include/spam-filter-information.php
@@ -11,7 +11,7 @@
 of incoming email, these reports will be coming from the following domains:
 </p>
 
-<TABLE CELLSPACING="0" CELLPADDING="5" BORDER="1">
+<TABLE class="bordered" CELLPADDING="5">
 <TR><TD>domain</TD><TD>reason</TD></TR>
 <TR><TD NOWRAP><CODE CLASS="code">freshports.org</CODE></TD><TD>All reports originate from that domain.</TD></TR>
 <TR><TD NOWRAP><CODE CLASS="code">unixathome.org</CODE></TD><TD>The websites are hosted on a box in that domain.</TD></TR>

--- a/include/watch-lists.php
+++ b/include/watch-lists.php
@@ -77,7 +77,7 @@ function freshports_WatchListDDLBForm($db, $UserID, $WatchListID, $Extra = '') {
 	
 	$HTML = '
 <form action="' . $_SERVER["PHP_SELF"] . '" method="POST" NAME=f>
-<table border="0">
+<table class="borderless">
 <tr>
 <td valign="top" nowrap align="right">
 <small>
@@ -120,7 +120,7 @@ function freshports_UpdatingOutput($NumRowsUpdating, $PortsUpdating, $port) {
 	$HTML = '';
 	
 	if ($NumRowsUpdating > 0) {
-		$HTML .= '<TABLE BORDER="1" width="100%" CELLSPACING="0" CELLPADDING="5">' . "\n";
+		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
 		$HTML .= "<TR>\n";
 		$HTML .= freshports_PageBannerText('<a id="updating">Notes from UPDATING</a>', 1);
 		$HTML .= "<tr><td><dl>\n";

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -38,7 +38,7 @@ function DisplayPortCommits($port, $PageNumber) {
 	$NumRowsTo      = $PortsMovedTo->FetchInitialiseTo($port->id);
 
 	if ($NumRowsFrom + $NumRowsTo > 0) {
-		$HTML .= '<TABLE BORDER="1" width="100%" CELLSPACING="0" CELLPADDING="5">' . "\n";
+		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
 		$HTML .= "<TR>\n";
 		$HTML .= freshports_PageBannerText("Port Moves", 1);
 		$HTML .= "<tr><td>\n";

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -21,7 +21,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" HEIGHT="29"><FONT COLOR="#FFFFFF"><BIG><BIG>
+    <TD class="accent" HEIGHT="29"><FONT COLOR="#FFFFFF"><BIG><BIG>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>

--- a/www/about.php
+++ b/www/about.php
@@ -127,7 +127,7 @@ About the Authors</A> for details of who else helped.</P>
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -81,14 +81,14 @@ if (IsSet($_REQUEST['edit'])) {
                'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <?php
 
 
 if (isset($errors)) {
 echo '
-  <TABLE width="100%" CELLPADDING="3" BORDER="0">
+  <TABLE CELLPADDING="3" class="fullwidth borderless">
   <TR VALIGN=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD width="100%">
@@ -103,7 +103,7 @@ echo '
 <br>';
 }
 
-echo '<TABLE CELLPADDING="1" CELLSPACING="3" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD BGCOLOR="' . BACKGROUND_COLOUR . '" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>' . $Title . '</BIG></BIG></FONT></TD>
 </TR>
@@ -115,7 +115,7 @@ echo 'Current annoucements<blockquote>';
 $HTML  = '';
 $HTML .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST">' . "\n";
 
-$HTML .= '<table cellpadding="4" cellspacing="0" border="1">' . "\n";
+$HTML .= '<table cellpadding="4" class="bordered">' . "\n";
 
 $HTML .= '<tr><td><b>Announcement Text (can be HTML)</b></td><td><b>Start Date</b></td><td><b>End Date</b></td></tr>' . "\n";
 
@@ -169,7 +169,7 @@ echo "<p></blockquote></TD>
 
 function MyDisplayAnnouncements($Announcement) {
         $HTML = '';
-	$HTML .= '<table cellpadding="4" cellspacing="0" border="1">' . "\n";
+	$HTML .= '<table cellpadding="4" class="bordered">' . "\n";
 	$HTML .= '<tr><td><b>Announcement Text</b></td><td><b>Start Date</b></td><td><b>End Date</b></td><td><b>Edit</b></td><td><b>Delete</b</td></tr>' . "\n";
 
 	$NumRows = $Announcement->NumRows();

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -103,9 +103,9 @@ echo '
 <br>';
 }
 
-echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless accent">
 <TR>
-<TD BGCOLOR="' . BACKGROUND_COLOUR . '" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>' . $Title . '</BIG></BIG></FONT></TD>
+<TD class="accent" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>' . $Title . '</BIG></BIG></FONT></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -20,10 +20,10 @@
 
 ?>
 
-<TABLE width="<? echo $TableWidth ?>" border="0" ALIGN="center">
+<TABLE width="<? echo $TableWidth ?>" class="borderless" ALIGN="center">
 
 <TR><TD valign="top" width="100%">
-<TABLE width="100%" border="0">
+<TABLE class="fullwidth borderless">
 <TR>
 	<? echo freshports_PageBannerText($Title); ?>
 </TR>
@@ -35,7 +35,7 @@
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../configuration/status-config.php');
 
-echo '<table border="1">' . "\n";
+echo '<table class="bordered">' . "\n";
 echo '<tr><td></td><td align="center" colspan="' . count($sites) . '">sites - yeah, we can\'t do this yet from the front end</td></tr>' . "\n";
 echo '<tr><td>queues</td>';
 foreach ($sites as $site) {
@@ -68,7 +68,7 @@ $result = pg_exec($db, $sql);
 if ($result) {
 	$numrows = pg_numrows($result);
 	if ($numrows) {
-		echo '<table border="1" cellpadding="5" cellspacing="3">' . "\n";
+		echo '<table class="bordered" cellpadding="5" cellspacing="3">' . "\n";
 		echo "<caption>The package imports</caption><tr>
 		<td><b>ABI</b>
 		<td><b>package set</b></td>
@@ -111,7 +111,7 @@ $result = pg_exec($db, $sql);
 if ($result) {
 	$numrows = pg_numrows($result);
 	if ($numrows) {
-		echo '<table border="1">' . "\n";
+		echo '<table class="bordered">' . "\n";
 		echo "<tr><td><b>Days</b><td><b>Users</b></td></tr>\n";
 	
 		$i=0;

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -40,9 +40,9 @@
 					'FreeBSD, index, applications, ports');
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD VALIGN="top" WIDTH="100%">
-<TABLE WIDTH="100%" BORDER="0">
+<TABLE class="fullwidth borderless">
 
 <TR>
 	<? echo freshports_PageBannerText($Title . ' - ' . $CategoryName); ?>
@@ -63,7 +63,7 @@ if (!$IsPrimary) {
 }
 ?>
 
-<table cellpadding="5" cellspacing="0" border="1">
+<table cellpadding="5" class="bordered">
 <tr><td><b>id</b></td><td><b>is_primary</b></td><td><b>element_id</b></td><td><b>name</b></td><td><b>description</b></td></tr>
 <tr><?php
 echo '<td>' . $Category->id          . '</td>';

--- a/www/commits.php
+++ b/www/commits.php
@@ -75,7 +75,7 @@ function freshports_SummaryForDay($MinusN) {
    $File = $BaseDirectory . "/" . date("Y/m/d", $Now - 60*60*24*$MinusN) . ".inc";
 //   echo "$File<br>\n";
    if (file_exists($File)) {
-      echo '<br><TABLE WIDTH="152" BORDER="1" CELLSPACING="0" CELLPADDING="5">';
+      echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
       echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
@@ -185,7 +185,7 @@ A port is marked as new for 10 days.
 		if ($NumberOfDays) {
 			$Today = time();
 			echo '
-<TABLE WIDTH="155" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
 		<TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>

--- a/www/commits.php
+++ b/www/commits.php
@@ -77,7 +77,7 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
       echo '</font></TD>';
       echo '       </TR>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/confirmation.php
+++ b/www/confirmation.php
@@ -37,7 +37,7 @@
 
 <?php echo freshports_MainTable(); ?>
 <tr><td VALIGN=TOP width="100%">
-<TABLE WIDTH="100%">
+<TABLE class="fullwidth">
 <TR>
 	<? echo freshports_PageBannerText("Account confirmation"); ?>
 </TR>

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -203,7 +203,21 @@ a > img {
   border: 0;
 }
 
+table.fullwidth {
+  width: 100%;
+}
 
+table.borderless {
+  border: 0 none black;
+}
+
+table.bordered {
+  border: 1px outset black;
+}
+
+table.bordered > tbody > tr > td {
+  border: 1px inset black;
+}
 
 td.version:hover {
   background-color: #777;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -222,6 +222,7 @@ table.borderless {
 
 table.bordered {
   border: 1px outset black;
+  border-spacing: 0;
 }
 
 table.bordered > tbody > tr > td {

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -1,6 +1,15 @@
+:root {
+  --beastie-red: #8c0707;
+}
+
 BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 {
     font-size: 12px;
+}
+
+.accent {
+  background-color: #8c0707;
+  background-color: var(--beastie-red);
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -199,6 +199,10 @@ div.scrollmenu table {
   display: inline-block;
 }
 
+a > img {
+  border: 0;
+}
+
 
 
 td.version:hover {

--- a/www/customize.php
+++ b/www/customize.php
@@ -158,23 +158,23 @@ UPDATE users
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
-<TABLE width="100%" border="0">
+<TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" width="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth bordeless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD>
-<TABLE width="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE width="100%" CELLPADDING="3" BORDER="0">
+  <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD width="100%">
@@ -198,10 +198,10 @@ if ($AccountModified) {
    echo "Your account details were successfully updated.";
 } else {
 
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD VALIGN="top">
-<TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
 <TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
 </TR>

--- a/www/customize.php
+++ b/www/customize.php
@@ -166,11 +166,11 @@ UPDATE users
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth bordeless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth bordeless accent">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -198,12 +198,12 @@ if ($AccountModified) {
    echo "Your account details were successfully updated.";
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/date.php
+++ b/www/date.php
@@ -127,7 +127,7 @@
 		$HTML = '';
 
 		if ($NumRows == 0) {
-			$HTML .= '<TR><TD COLSPAN="3" BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="0">' . "\n";
+			$HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
 			$HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($Date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
 			$HTML .= '</TD></TR>' . "\n\n";
 			$HTML .= '<TR><TD>No commits found for that date</TD></TR>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -84,11 +84,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Deleted Failed!</font></b></TD>
+<TR class="accent"><TD><b><font color="#ffffff" size=+0>Deleted Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -113,12 +113,12 @@ echo '<p>If you need help, please email postmaster@. </p>
 <br>';
 }  // if ($errors)
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -76,23 +76,23 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
-<TABLE width="100%" border="0">
+<TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" width="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD>
-<TABLE width="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Deleted Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE width="100%" CELLPADDING="3" BORDER="0">
+  <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD width="100%">
@@ -113,10 +113,10 @@ echo '<p>If you need help, please email postmaster@. </p>
 <br>';
 }  // if ($errors)
 
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD VALIGN="top">
-<TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
 <TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
 </TR>
@@ -136,7 +136,7 @@ require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
 
 ?>
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" border="0" cellpadding="1">
+<TABLE width="*" class="borderless" cellpadding="1">
           <TR>
             <TD VALIGN="top">
                <p>The account name is: <?php echo $User->name; ?><p>

--- a/www/faq.php
+++ b/www/faq.php
@@ -455,7 +455,7 @@ of a link to a page of commits for that day.
 
 Here are a few examples:
 <blockquote>
-<table BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<table class="bordered" CELLPADDING="5">
 <tr>
 <td><b>Description</b></td>
 <td nowrap valign="top"><b>URL</b></td>
@@ -685,7 +685,7 @@ if you can provide a URL that exercises all the options that require testing.
    <P>
 	For those familiar with the FreeBSD ports structure, the following fields indicate their origin:
 
-<table cellpadding="5" cellspacing="0" border="0">
+<table cellpadding="5" class="borderless">
 <tr><td><b>Field</b></td><td><b>Origin</b></td></tr>
 <tr><td>Port Name</td><td><code class="code">PORTNAME</code></td></tr>
 <tr><td>Package Name</td><td><code class="code">PKGNAME</code></td></tr>

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -118,7 +118,7 @@ if ($_REQUEST['wlid']) {
 <tr><td valign="top" width="100%">
 
 
-<table width="100%" border="0">
+<table class="fullwidth borderless">
 <?php # list of categories table start ?>
 <tr><td>
 This screen contains a list of the port categories. A * indicates a category that contains ports which are
@@ -130,7 +130,7 @@ Virtual categories cannot be watched and their checkboxes will be disabled.
 </td>
 
 <td valign="top">
-<table border="0">
+<table class="borderless">
 <?php # ddlb start ?>
 <tr><td>Select...</td></tr>
 <tr><td align="left">
@@ -210,7 +210,7 @@ for ($i = 0; $i < $numrows; $i++) {
 
 # categories list start
 
-$HTML .= "\n" . '<TABLE BORDER="1" CELLSPACING="0" CELLPADDING="5">' . "\n";
+$HTML .= "\n" . '<TABLE class="bordered" CELLPADDING="5">' . "\n";
 $HTML .= '<tr>';
 // get the list of categories to display
 $sql = "

--- a/www/filter.php
+++ b/www/filter.php
@@ -63,7 +63,7 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
       echo '</font></TD>';
       echo '       </TR>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/filter.php
+++ b/www/filter.php
@@ -61,7 +61,7 @@ function freshports_SummaryForDay($MinusN) {
    $File = $BaseDirectory . "/" . date("Y/m/d", $Now - 60*60*24*$MinusN) . ".inc";
 //   echo "$File<br>\n";
    if (file_exists($File)) {
-      echo '<br><TABLE WIDTH="152" BORDER="1" CELLSPACING="0" CELLPADDING="5">';
+      echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
       echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
@@ -185,7 +185,7 @@ A port is marked as new for 10 days.
 		if ($NumberOfDays) {
 			$Today = time();
 			echo '
-<TABLE WIDTH="155" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
 		<TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -134,23 +134,23 @@ if (IsSet($submit)) {
                'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="100%" BORDER="0">
+<TABLE class="fullwidth borderless">
  <TR>
     <TD>
-<TABLE WIDTH="100%" BORDER="0">
+<TABLE class="fullwidth borderless">
 <TR><TD VALIGN="top" WIDTH="100%">
 <?
 
 if (IsSet($error) and $error != '') {
-      echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
             <TR>
             <TD>
-               <TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+               <TABLE class="fullwidth borderless" CELLPADDING="1">
                   <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><FONT COLOR="#ffffff" SIZE="+2">We have a problem!</FONT></b></TD>
                  </TR> 
                  <TR BGCOLOR="#ffffff">
             <TD>
-              <TABLE WIDTH="100%" CELLPADDING="3" BORDER="0">
+              <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN="middle">
                <TD><img src="/images/warning.gif" ALT="warning!"></TD>
                <TD WIDTH="100%">
@@ -169,15 +169,15 @@ if (IsSet($error) and $error != '') {
 } else {
 
    if ($LoginFailed || $eMailFailed) {
-      echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
             <TR>
             <TD>
-               <TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+               <TABLE class="fullwidth borderless" CELLPADDING="1">
                   <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><FONT COLOR="#ffffff" SIZE="+2">UserID not found!</FONT></b></TD>
                  </TR>
                  <TR BGCOLOR="#ffffff">
             <TD>
-              <TABLE WIDTH="100%" CELLPADDING="3" BORDER="0">
+              <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN=top>
                <TD><img src="/images/warning.gif" ALT="warning!"></TD>
                <TD WIDTH="100%">
@@ -211,10 +211,10 @@ if (IsSet($error) and $error != '') {
 }
 ?>
 
-<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" WIDTH="100%"> <TR> <TD>
+<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"> <TR> <TD>
 
 
-<TABLE WIDTH="100%" BORDER="0" CELLPADDING="5" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>">
+<TABLE class="fullwidth borderless" CELLPADDING="5" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>">
 
 <TR BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"><TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"><FONT COLOR="#ffffff" SIZE="+2">
 <?

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -142,11 +142,11 @@ if (IsSet($submit)) {
 <?
 
 if (IsSet($error) and $error != '') {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                  <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><FONT COLOR="#ffffff" SIZE="+2">We have a problem!</FONT></b></TD>
+                  <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">We have a problem!</FONT></b></TD>
                  </TR> 
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -169,11 +169,11 @@ if (IsSet($error) and $error != '') {
 } else {
 
    if ($LoginFailed || $eMailFailed) {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                  <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><FONT COLOR="#ffffff" SIZE="+2">UserID not found!</FONT></b></TD>
+                  <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">UserID not found!</FONT></b></TD>
                  </TR>
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -211,12 +211,12 @@ if (IsSet($error) and $error != '') {
 }
 ?>
 
-<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"> <TR> <TD>
+<TABLE CELLPADDING="1" class="fullwidth borderless accent"> <TR> <TD>
 
 
-<TABLE class="fullwidth borderless" CELLPADDING="5" BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>">
+<TABLE class="fullwidth borderless accent" CELLPADDING="5">
 
-<TR BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"><TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>"><FONT COLOR="#ffffff" SIZE="+2">
+<TR class="accent" ><TD class="accent"><FONT COLOR="#ffffff" SIZE="+2">
 <?
 if ($MailSent) {
    echo "Mail sent to your address";

--- a/www/fp2-announcement.php
+++ b/www/fp2-announcement.php
@@ -39,7 +39,7 @@ for a full list of features.  The following is a short list of some of the chang
 </P>
 
 
-<TABLE WIDTH="100%" CELLPADDING="4" CELLSPACING="4">
+<TABLE class="fullwidth" CELLPADDING="4" CELLSPACING="4">
 <TR>
 <TD NOWRAP VALIGN="top" ALIGN="right"><B>Face lift</B></TD>
 	<TD>
@@ -93,7 +93,7 @@ for a full list of features.  The following is a short list of some of the chang
 <H2>Technical changes</H2>
 The following items deal with the technical changes which have occurred.
 
-<TABLE WIDTH="100%" CELLPADDING="4" CELLSPACING="4">
+<TABLE class="fullwidth" CELLPADDING="4" CELLSPACING="4">
 <TR>
 <TD NOWRAP VALIGN="top" ALIGN="right"><B>database</B></TD>
 	<TD>

--- a/www/graphs.php
+++ b/www/graphs.php
@@ -49,7 +49,7 @@ If you have suggestions for graphs, please raise an issue.
 
 <TR><TD>
 
-<TABLE WIDTH="100%" BORDER="0">
+<TABLE class="fullwidth borderless">
 <TR>
 <TD WIDTH="300" VALIGN="top">
 <?

--- a/www/graphs2.php
+++ b/www/graphs2.php
@@ -78,7 +78,7 @@ Thank you for your help.
 
 <TR><TD>
 
-<TABLE WIDTH="100%" BORDER="0">
+<TABLE class="fullwidth borderless">
 <TR align="center">
 <TD WIDTH="300" VALIGN="top">
 <?php

--- a/www/index.php
+++ b/www/index.php
@@ -79,7 +79,7 @@ function freshports_SummaryForDay($MinusN) {
    $File = $BaseDirectory . "/" . date("Y/m/d", $Now - 60*60*24*$MinusN) . ".inc";
 //   echo "$File<br>\n";
    if (file_exists($File)) {
-      echo '<br><TABLE WIDTH="152" BORDER="1" CELLSPACING="0" CELLPADDING="5">';
+      echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
       echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
@@ -212,7 +212,7 @@ if ($db) {
 		if ($NumberOfDays) {
 			$Today = time();
 			echo '
-<TABLE WIDTH="155" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
 		<TD BGCOLOR="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>

--- a/www/index.php
+++ b/www/index.php
@@ -81,7 +81,7 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
       echo '</font></TD>';
       echo '       </TR>';
@@ -214,7 +214,7 @@ if ($db) {
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD BGCOLOR="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/inthenews.php
+++ b/www/inthenews.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 <tr><td valign="top" width="100%">
-<table width="100%" border="0">
+<table class="fullwidth borderless">
   <tr>
 	<? echo freshports_PageBannerText("In the news"); ?>
   </tr>

--- a/www/legal.php
+++ b/www/legal.php
@@ -25,7 +25,7 @@
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
   <TR>
-    <TD bgcolor="<?php echo BACKGROUND_COLOUR; ?>" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">LEGAL NOTICE</FONT></TD>
+    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">LEGAL NOTICE</FONT></TD>
   </TR>
   <TR><TD>This page contains our obligatory legal notice.  I really don't like having to say
           these things, but given the nature of some people, I must.  For the rest of you,
@@ -33,7 +33,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">COPYRIGHT</FONT></TD>
+    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">COPYRIGHT</FONT></TD>
   </TR>
   <TR><TD>
   <p>Copyright <?php echo COPYRIGHTYEARS; ?> Dan Langille All rights reserved.&nbsp; Copyright in
@@ -49,7 +49,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">CONTENT AND LIABILITY DISCLAIMER</FONT></TD>     
+    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">CONTENT AND LIABILITY DISCLAIMER</FONT></TD>
   </TR>
   <TR><TD>
   <p>Dan Langille shall not be responsible for any errors or omissions contained at
@@ -68,7 +68,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">FEEDBACK INFORMATION</FONT></TD>
+    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">FEEDBACK INFORMATION</FONT></TD>
   </TR>
   <TR><TD>
   <p>Any information provided to Dan Langille in connection with any Dan Langille
@@ -78,7 +78,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">TRADEMARKS</FONT></TD>
+    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">TRADEMARKS</FONT></TD>
   </TR>
   <TR><TD>
   <p>All Dan Langille's product names are trademarks or registered trademarks of Dan Langille

--- a/www/login.php
+++ b/www/login.php
@@ -142,13 +142,13 @@ if ($LoginFailed) {
 <?php echo freshports_ErrorContentTable(); ?>
 
 <TR><TD VALIGN=TOP>
-<TABLE WIDTH="100%">
+<TABLE class="fullwidth">
 <TR>
 	<? echo freshports_PageBannerText("Login Failed!") ?>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE WIDTH="100%" CELLPADDING=0 CELLSPACING=0 BORDER=0>
+  <TABLE class="fullwidth borderless" CELLPADDING="0">
   <TR valign=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD WIDTH="100%">
@@ -176,14 +176,14 @@ if ($error) {
 ?>
 <?php echo freshports_ErrorContentTable(); ?>
 <TR><TD VALIGN=TOP>
-<TABLE WIDTH="100%">
+<TABLE class="fullwidth">
 <TR>
     <? echo freshports_PageBannerText("NOTICE"); ?>
 </TR>
 
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE WIDTH="100%" CELLPADDING=0 BORDER=0>
+  <TABLE class="fullwidth borderless" CELLPADDING=0>
   <TR valign=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD WIDTH="100%">
@@ -204,7 +204,7 @@ if ($error) {
 
 
 
-echo '<TABLE WIDTH="100%" BORDER="1" CELLPADDING="1" CELLSPACING="0" BGCOLOR="' . BACKGROUND_COLOUR . '">';
+echo '<TABLE class="fullwidth bordered" CELLPADDING="1" BGCOLOR="' . BACKGROUND_COLOUR . '">';
 
 echo '<TR BGCOLOR="' . BACKGROUND_COLOUR . '">';
 

--- a/www/login.php
+++ b/www/login.php
@@ -204,9 +204,9 @@ if ($error) {
 
 
 
-echo '<TABLE class="fullwidth bordered" CELLPADDING="1" BGCOLOR="' . BACKGROUND_COLOUR . '">';
+echo '<TABLE class="fullwidth bordered accent" CELLPADDING="1">';
 
-echo '<TR BGCOLOR="' . BACKGROUND_COLOUR . '">';
+echo '<TR class="accent">';
 
 echo freshports_PageBannerText("Login");
 echo '</TR>';

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -180,11 +180,11 @@ if (IsSet($submit)) {
 <TR><TD VALIGN="top" WIDTH="100%">
 <?php
 if ($errors != '') {
-echo '<TABLE CELLPADDING=1 class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING=1 class="fullwidth borderless accent">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING=1>
-<TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><B><FONT color="#ffffff" size=+0>Access Code Failed!</FONT></B></TD>
+<TR class="accent"><TD><B><FONT color="#ffffff" size=+0>Access Code Failed!</FONT></B></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -180,15 +180,15 @@ if (IsSet($submit)) {
 <TR><TD VALIGN="top" WIDTH="100%">
 <?php
 if ($errors != '') {
-echo '<TABLE CELLPADDING=1 CELLSPACING=0 BORDER=0 BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH=100%>
+echo '<TABLE CELLPADDING=1 class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD>
-<TABLE WIDTH=100% BORDER=0 CELLPADDING=1>
+<TABLE class="fullwidth borderless" CELLPADDING=1>
 <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><B><FONT color="#ffffff" size=+0>Access Code Failed!</FONT></B></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE WIDTH=100% CELLPADDING=3 CELLSPACING=0 BORDER=0>
+  <TABLE class="fullwidth borderless" CELLPADDING=3>
   <TR VALIGN=top>
    <TD><IMG SRC="/images/warning.gif"></TD>
    <TD WIDTH=100%>

--- a/www/package.php
+++ b/www/package.php
@@ -70,7 +70,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -103,11 +103,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -137,12 +137,12 @@ if ($PasswordReset) {
 
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Reset password via token</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Reset password via token</BIG></BIG></FONT></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -95,23 +95,23 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
-<TABLE width="100%" border="0">
+<TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" width="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD>
-<TABLE width="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR BGCOLOR="' . BACKGROUND_COLOUR . '"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
-  <TABLE width="100%" CELLPADDING="3" BORDER="0">
+  <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
    <TD><img src="/images/warning.gif"></TD>
    <TD width="100%">
@@ -137,10 +137,10 @@ if ($PasswordReset) {
 
 } else {
 
-echo '<TABLE CELLPADDING="1" BORDER="0" BGCOLOR="' . BACKGROUND_COLOUR . '" WIDTH="100%">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless" BGCOLOR="' . BACKGROUND_COLOUR . '">
 <TR>
 <TD VALIGN="top">
-<TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
 <TD BGCOLOR="' . BACKGROUND_COLOUR . '" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Reset password via token</BIG></BIG></FONT></TD>
 </TR>

--- a/www/pkg_process.inc
+++ b/www/pkg_process.inc
@@ -41,16 +41,16 @@ function HandleFileUpload($FormFileName, $Destination) {
 
 function DisplayError($error) {
 ?>
-	<TABLE WIDTH="100%" ALIGN="center" CELLPADDING="1" CELLSPACING="0" BORDER="1">
+	<TABLE class="fullwidth bordered" ALIGN="center" CELLPADDING="1">
 	<TR><TD VALIGN=TOP>
-		<TABLE WIDTH="100%">
+		<TABLE class="fullwidth">
 			<TR>
 			    <? echo freshports_PageBannerText("NOTICE"); ?>
 			</TR>
 
 			<TR BGCOLOR="#ffffff">
 				<TD>
-					<TABLE WIDTH="100%" CELLPADDING="0" CELLSPACING="0" BORDER="0">
+					<TABLE class="fullwidth borderless" CELLPADDING="0">
 						<TR VALIGN="top">
 							<TD VALIGN="middle"><IMG SRC="/images/warning.gif" ALT="warning"></TD>
 							<TD VALIGN="middle" width="100%">
@@ -215,7 +215,7 @@ function UploadDisplayStagingResultsMatches($UserID, $WatchListID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
 			<TR><TD COLSPAN="2"><B>Port name</B> <SMALL>(<? echo $numrows ?> port<?php if ($numrows > 1) echo 's'; ?>)</SMALL></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?
@@ -272,7 +272,7 @@ function UploadDisplayStagingResultsMatchesNo($UserID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
 			<TR><TD><B>Port name</B> <SMALL>(<? echo $numrows ?> port<?php if ($numrows > 1) echo 's'; ?>)</SMALL></TD><TD><SMALL>search</SMALL></TD></TR>
 
 			<?
@@ -316,7 +316,7 @@ function UploadDisplayStagingResultsMatchesDuplicates($UserID, $WatchListID, $db
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
 			<TR><TD><B>Port name</B></TD><TD><B>Count</B></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?
@@ -378,7 +378,7 @@ function UploadDisplayWatchListItemsNotInStagingArea($WatchListID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
 			<TR><TD><B>Port name</B></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -64,7 +64,7 @@ function DisplayUploadForm($db, $UserID) {
 	copy/paste the results into a form.
 	</p>
 
-	<table border="1" cellpadding="5" cellspacing="0" width="100%">
+	<table class="fullwidth bordered" cellpadding="5">
 	<tr>
 	<td valign="top">
 	<h2>Uploading a file</h2>
@@ -151,7 +151,7 @@ echo freshports_WatchListDDLB($db, $UserID);
 
 function DisplayStagingArea($UserID, $WatchListID, $db) {
 
-	echo '<TABLE ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5">';
+	echo '<TABLE ALIGN="center" class="bordered" CELLPADDING="5">';
 ?>
 
 	<TR><TD COLSPAN="4"><BIG>The following information is in your Staging Area.  To save it to a Watch List, 
@@ -160,7 +160,7 @@ function DisplayStagingArea($UserID, $WatchListID, $db) {
 
 	<TR><TD COLSPAN="4">
 	<FORM ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
-	<table width="100%" border="0">
+	<table class="fullwidth borderless">
 	<tr><td align="center">
 			<INPUT TYPE="submit" VALUE="Update watch list"  NAME="update_watch_list" SIZE="40">
 			&nbsp;&nbsp;&nbsp;
@@ -209,14 +209,14 @@ function DisplayStagingArea($UserID, $WatchListID, $db) {
 
 function ChooseWatchLists($UserID, $db) {
 
-	echo '<TABLE width="100%" ALIGN="center" BORDER="1" CELLSPACING="0" CELLPADDING="5"><TR>';
+	echo '<TABLE class="fullwidth bordered" ALIGN="center" CELLPADDING="5"><TR>';
 ?>
 
 	<TR><TD colspan="3"><BIG>Your staging area contains your uploaded information.  Please choose a watch list, and click on Go.
 		 <SMALL><A HREF="/help.php">help</A></SMALL></TD></TR>
 
 	<TR><TD>
-	<table width="100%" border="0"><tr><td>
+	<table class="fullwidth borderless"><tr><td>
 			<FORM ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
 			<P ALIGN="center">
  			<INPUT TYPE="submit" VALUE="Empty staging area" NAME="clear">

--- a/www/port-watch.php
+++ b/www/port-watch.php
@@ -190,8 +190,8 @@ $HTML .= '<tr><td valign="top" ALIGN="center">' . "\n";
 
 if ($numrows) {
 	
-	$HTML .= '<table border="0">' . "\n" . '<tr><td>' . "\n";
-	$HTML .= '<table border="0">' . "\n" . '<tr><td>' . "\n";
+	$HTML .= '<table class="borderless">' . "\n" . '<tr><td>' . "\n";
+	$HTML .= '<table class="borderless">' . "\n" . '<tr><td>' . "\n";
 
 	$HTML .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST">' . "\n";
    // save the number of categories for when we submit
@@ -199,7 +199,7 @@ if ($numrows) {
    $HTML .= '<input type="hidden" name="category" value="' . $category . '">' . "\n";
    $HTML .= '<input type="hidden" name="wlid"     value="' . $wlid     . '">' . "\n";
 
-   $HTML .= "\n" . '<TABLE BORDER="1" CELLSPACING="0" CELLPADDING="5">' . "\n<tr>\n";
+   $HTML .= "\n" . '<TABLE class="bordered" CELLPADDING="5">' . "\n<tr>\n";
    $RowCount = ceil($NumPorts / (double) 4);
    $Row = 0;
    for ($i = 0; $i < $NumPorts; $i++) {
@@ -253,7 +253,7 @@ if ($numrows) {
 </table>
 
 <td valign="top">
-<table border="0"><tr><td>Select...</td></tr><tr><td>
+<table class="borderless"><tr><td>Select...</td></tr><tr><td>
    
 <?php
 	$Extra = '<input type="hidden" name="category" value="' . $category . '">';

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -211,7 +211,7 @@ needed.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -174,7 +174,7 @@ by the Revision Details icon (<?php echo freshports_Revision_Icon(); ?>).
 The <a href="/search.php">search page</a> now allows you to search by 
 the following fields.
 <blockquote>
-<table cellpadding="5" cellspacing="0" border="0">
+<table cellpadding="5" class="borderless">
 <tr><td><b>Field</b></td><td><b>Origin</b></td></tr>
 <tr><td>Port Name</td><td><code class="code">PORTNAME</code></td></tr>
 <tr><td>Package Name</td><td><code class="code">PKGNAME</code></td></tr>
@@ -202,7 +202,7 @@ the following fields.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -143,7 +143,7 @@
   <TR>
 
 <TD WIDTH="100%" VALIGN="top">
-<TABLE WIDTH="100%" BORDER="0" CELLPADDING="1">
+<TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
 <TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG><? echo $ArticleTitle; ?></BIG></BIG></FONT></TD>
 </TR>
@@ -155,7 +155,7 @@ This page allows you to select the reports you wish to receive and the frequency
 </p>
 
 <FORM ACTION="<?php echo $_SERVER["PHP_SELF"] ;?>" METHOD="POST" NAME=f>
-	<TABLE CELLPADDING="3" CELLSPACING="0" BORDER="1">
+	<TABLE CELLPADDING="3" class="bordered">
 	<TR><TD><BIG><B>Report Name</B></BIG></TD><TD><BIG><B>Frequency</B></BIG></TD><TD><BIG><B>Description</B></BIG></TD></TR>
 	<?
 

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -145,7 +145,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD BGCOLOR="<?php echo BACKGROUND_COLOUR; ?>" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG><? echo $ArticleTitle; ?></BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG><? echo $ArticleTitle; ?></BIG></BIG></FONT></TD>
 </TR>
 <TR>
 <TD>

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -42,7 +42,7 @@ function freshports_SummaryForDay($MinusN) {
    $File = $BaseDirectory . "/" . date("Y/m/d", $Now - 60*60*24*$MinusN) . ".inc";
 //   echo "$File<br>\n";
    if (file_exists($File)) {
-      echo '<br><TABLE WIDTH="152" BORDER="1" CELLSPACING="0" CELLPADDING="5">';
+      echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
       echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
@@ -212,7 +212,7 @@ since 10 October 2006.
 		if ($NumberOfDays) {
 			$Today = time();
 			echo '
-<TABLE WIDTH="155" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
 		<TD BGCOLOR="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -44,7 +44,7 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD bgcolor="' . BACKGROUND_COLOUR . '" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
       echo '</font></TD>';
       echo '       </TR>';
@@ -214,7 +214,7 @@ since 10 October 2006.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD BGCOLOR="' . BACKGROUND_COLOUR . '" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/search.php
+++ b/www/search.php
@@ -928,7 +928,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 	<BR><br>
 
-<table cellpadding="5" cellspacing="0" border="1">
+<table cellpadding="5" class="bordered">
 <tr>
 <td valign="middle">
 	<INPUT TYPE=checkbox <? if ($deleted == INCLUDE_DELETED_PORTS) echo 'CHECKED'; ?> VALUE=<?php echo INCLUDE_DELETED_PORTS; ?> NAME=deleted> Include deleted ports

--- a/www/vuxml.php
+++ b/www/vuxml.php
@@ -67,7 +67,7 @@ This page displays <a href="<?php echo VUXMLURL; ?>">vulnerability information</
 These are the vulnerabilities relating to the commit you have selected:
 </p>
 
-<table cellpadding="5" border="1" cellspacing="0">
+<table cellpadding="5" class="bordered">
 <tr><th align="left"><b>VuXML ID</b></th><th align="left"><b>Description</b></th></tr>
 <?php
 	if (!IsSet($vidArray)) {
@@ -137,7 +137,7 @@ SELECT V.vid,
 			$Count       = 0;
 			$NumPackages = 0;
 			$VIDs        = array();
-			echo '<table border="1">' . "\n";
+			echo '<table class="bordered">' . "\n";
 			echo '<th colspan="3">VuXML entries as processed by FreshPorts</th>';
 			echo '<tr><td><b>';
 			echo 'package';
@@ -230,7 +230,7 @@ ORDER BY coalesce(V.date_modified, V.date_entry, V.date_discovery)::date desc, V
 				$LastVID     = '';
 				$NumPackages = 0;
 				$VIDs        = 0;
-				echo '<table border="1" cellpadding="5" cellspacing="0">' . "\n";
+				echo '<table class="bordered" cellpadding="5">' . "\n";
 				echo '<th colspan="3">VuXML entries as processed by FreshPorts</th>';
 				echo '<tr><td><b>Date</b></td><td><b>';
 				echo 'Decscription';

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -66,7 +66,7 @@ if ($_REQUEST['wlid']) {
 <tr><td valign="top" width="100%">
 
 
-<table width="100%" border="0">
+<table class="fullwidth borderless">
 <?php # list of categories table start ?>
 <tr><td>
 This screen contains a list of the port categories. The categories with a * beside them contain ports which are
@@ -75,7 +75,7 @@ notification frequency within <a href="customize.php">your account</a>.
 </td>
 
 <td valign="top">
-<table border="0">
+<table class="borderless">
 <?php # ddlb start ?>
 <tr><td>Select...</td></tr>
 <tr><td align="left">
@@ -129,7 +129,7 @@ for ($i = 0; $i < $numrows; $i++) {
 
 # categories list start
 
-$HTML  = "\n" . '<TABLE BORDER="1" CELLSPACING="0" CELLPADDING="5">' . "\n";
+$HTML  = "\n" . '<TABLE class="bordered" CELLPADDING="5">' . "\n";
 $HTML .= '<tr>';
 // get the list of categories to display
 $sql = "

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -254,11 +254,11 @@ $ErrorMessage .= CheckForNoDefaultAndAddToDefault($db, $User);
 	}
 ?>
 <tr><td>
-<table WIDTH="100%" BORDER="0">
+<table class="fullwidth borderless">
 <tr><td valign="top">
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE WIDTH="100%" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE class="fullwidth bordered" CELLPADDING="5">
 <TR><td nowrap><BIG><b>Watch Lists</b></BIG></td><td><BIG><b>Actions</b></BIG> (scroll down for instructions)</td></tr>
   <TR>
     <TD valign="top">
@@ -294,7 +294,7 @@ $ErrorMessage .= CheckForNoDefaultAndAddToDefault($db, $User);
 
 </td><td valign="top">
 
-<TABLE WIDTH="100%" BORDER="1" CELLSPACING="0" CELLPADDING="5">
+<TABLE class="fullwidth bordered" CELLPADDING="5">
 <TR><td><BIG><b>Options</b></BIG></td></tr>
   <TR>
 <td valign="top" nowrap>

--- a/www/watch.php
+++ b/www/watch.php
@@ -70,12 +70,12 @@
 <?php echo freshports_MainTable(); ?>
 
 <tr><td valign="top" width="100%">
-<table width="100%" border="0">
+<table class="fullwidth borderless">
 <tr>
 	<? echo freshports_PageBannerText($Title); ?>
 </tr>
 <tr><td valign="top">
-<table border=0 width="100%">
+<table class="fullwidth borderless">
 <tr><td>
 <?php
 if ($wlid == '') {
@@ -112,7 +112,7 @@ $rowcount = $WatchListDeletedPorts->FetchInitialise($wlid);
 if ($rowcount)
 {
 echo '<hr><p>Some of your watched ports have moved.  You are still watching the old ports.</p>';
-echo '<table border="1" cellpadding="5" cellspacing="0">';
+echo '<table class="bordered" cellpadding="5">';
 echo '<tr><td><b>Old Port</b></td><td><b>Replaced by</b></td></tr>';
 for ($i = 0; $i < $rowcount; $i++) {
 	$WatchListDeletedPorts->FetchNth($i);


### PR DESCRIPTION
Rather large patch for what's hopefully a very simple change.

Starts work on modernising the HTML markup.

- Removes the use of the `border` attribute from `table` elements, replaced with CSS `bordered` and `borderless` classes, which should be visually equivalent (hopefully)
- Removes the use of the `border` attribute from `img` elements inside `a` elements (though this may be default these days)
- Removes the use of `cellspacing="0"` (this should be the default everywhere nowadays)
- Move the setting of `bgcolor` and the `BACKGROUND_COLOUR` constant to an `accent` CSS class

Border, cellspacing, width, and bgcolor are all deprecated in HTML4 Strict onwards.

I'm aware the classnames aren't great, open to suggestions there. 😃 I'm expecting these changes to look pretty much identical to the current markup, so if there's any issues would be great to see it in an environment or get screenshots. Hope this kind of patch is OK, if so I'll continue on with align, cellpadding, <font> tags, and other obsolete markup.

Notes:
- There's a bit of usage of the `$TableWidth` global to set width. It only seems to be set to `100%` that I can see so can probably be replaced with `.fullwidth` also, but that's not in these changes