### PR TITLE
Remove incorrectly merged stylesheet for div.scrollmenu

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -198,12 +198,6 @@ li.extraspace {
 
 /* for horizontal scrolling of package tables - re https://www.w3schools.com/howto/howto_css_menu_horizontal_scroll.asp#contact */
 
-div.scrollmenu {
-  background-color: #333;
-  overflow: scroll;
-  white-space: nowrap;
-}
-
 div.scrollmenu table {
   display: inline-block;
 }


### PR DESCRIPTION
These styles are different from prod on the package status table in a port details page.

See:
https://devgit.freshports.org/graphics/darktable/#packages
vs
https://www.freshports.org/graphics/darktable/#packages