### PR TITLE
HTML Cleanup: font, big, body[text], [bgcolor], [target], [width]

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -190,8 +190,8 @@ class DisplayCommit {
 					
 				if ($mycommit->svn_revision != '') {
 					if ($this->IsGitCommit($mycommit->message_id)) {
-						$this->HTML .= '&nbsp; ' .       freshports_git_commit_Link($mycommit->svn_revision,                               $mycommit->repo_hostname, $mycommit->path_to_repo);
-						$this->HTML .= '&nbsp; ' .  freshports_git_commit_Link_Hash($mycommit->svn_revision, $mycommit->commit_hash_short, $mycommit->repo_hostname, $mycommit->path_to_repo). '&nbsp';
+						$this->HTML .= '&nbsp; ' .      freshports_git_commit_Link($mycommit->svn_revision,                               $mycommit->repo_hostname, $mycommit->path_to_repo);
+						$this->HTML .= '&nbsp; ' . freshports_git_commit_Link_Hash($mycommit->svn_revision, $mycommit->commit_hash_short, $mycommit->repo_hostname, $mycommit->path_to_repo) . '&nbsp;';
 					} else {
 						$this->HTML .= '&nbsp; ' . freshports_svnweb_ChangeSet_Link($mycommit->svn_revision, $mycommit->repo_hostname);
 					}

--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -146,7 +146,7 @@ class DisplayCommit {
 
 				if ($mycommit->commit_date != $PreviousCommit->commit_date) {
 					$this->HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
-					$this->HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
+					$this->HTML .= '   ' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . "\n";
 					$this->HTML .= '</TD></TR>' . "\n\n";
 				}
 

--- a/classes/files-display.php
+++ b/classes/files-display.php
@@ -24,7 +24,6 @@ class FilesDisplay {
 	}
 
 	function CreateHTML($WhichRepo) {
-		GLOBAL $TableWidth;
 		GLOBAL $freshports_CommitMsgMaxNumOfLinesToShow;
 		GLOBAL $DaysMarkedAsNew;
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -976,7 +976,7 @@ function freshports_body($ExtraScript = null) {
 
 GLOBAL $Debug;
 
-echo "\n" . '<BODY bgcolor="#FFFFFF" TEXT="#000000">';
+echo "\n" . '<BODY bgcolor="#FFFFFF">';
 
 # most often used for page setup, hiding elements, etc
 if (!empty($ExtraScript)) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1599,7 +1599,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '">' . $Text . '</td>' . "\n";
+	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
 }
 
 
@@ -1765,7 +1765,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td class="accent" height="30"><b>Login</b></FONT></td>
+         <td class="accent" height="30"><b>Login</b></td>
         </tr>
         <tr>
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -973,7 +973,7 @@ function freshports_body($ExtraScript = null) {
 
 GLOBAL $Debug;
 
-echo "\n" . '<BODY bgcolor="#FFFFFF">';
+echo "\n" . '<BODY>';
 
 # most often used for page setup, hiding elements, etc
 if (!empty($ExtraScript)) {
@@ -1984,7 +1984,7 @@ function freshports_ErrorMessage($Title, $ErrorMessage) {
 <tr>
 	' . freshports_PageBannerText($Title) . '
 </tr>
-<tr bgcolor="#ffffff">
+<tr>
 <td>
   <table class="fullwidth borderless" cellpadding="0">
   <tr valign=top>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -499,7 +499,7 @@ function freshports_Ignore_Icon($HoverText = '') {
 	$Alt       = "Ignore";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="21;">';
+	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="21">';
 }
 
 function freshports_Ignore_Icon_Link($HoverText = '') {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1599,7 +1599,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><FONT COLOR="#FFFFFF"><big><big>' . $Text . '</big></big></FONT></td>' . "\n";
+	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '">' . $Text . '</td>' . "\n";
 }
 
 
@@ -1765,7 +1765,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Login</b></big></FONT></td>
+         <td class="accent" height="30"><b>Login</b></FONT></td>
         </tr>
         <tr>
 
@@ -1814,7 +1814,7 @@ function freshports_SideBar() {
 	$HTML .= '	
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>This site</b></big></FONT></td>
+		<td class="accent" height="30"><b>This site</b></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1833,7 +1833,7 @@ function freshports_SideBar() {
 <br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Search</b></big></FONT></td>
+		<td class="accent" height="30"><b>Search</b></td>
 	</tr>
 	<tr>
 
@@ -1857,7 +1857,7 @@ function freshports_SideBar() {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Latest Vulnerabilities</b></big></FONT></td>
+		<td class="accent" height="30"><b>Latest Vulnerabilities</b></td>
 	</tr>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
@@ -1876,7 +1876,7 @@ $HTML .= '<br>
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Ports</b></big></FONT></td>
+		<td class="accent" height="30"><b>Ports</b></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1898,7 +1898,7 @@ if (IsSet($visitor)) {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Watch Lists</b></big></FONT></td>
+		<td class="accent" height="30"><b>Watch Lists</b></td>
 	</tr>
 	<tr>
 	<td valign="top">';
@@ -1933,7 +1933,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td COLSPAN="2" class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Statistics</b></big></FONT></td>
+		<td COLSPAN="2" class="accent" height="30"><b>Statistics</b></td>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -29,7 +29,7 @@ DEFINE('UNMAINTAINTED_ADDRESS', 'ports@freebsd.org');
 
 DEFINE('CLICKTOADD', 'Click to add this to your default watch list[s]');
 
-DEFINE('SPONSORS', 'Servers and bandwidth provided by<br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_new">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_new">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_new">RootBSD</a>');
+DEFINE('SPONSORS', 'Servers and bandwidth provided by<br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_blank">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_blank">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_blank">RootBSD</a>');
 
 DEFINE('FRESHPORTS_ENCODING', 'UTF-8');
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -40,9 +40,7 @@ date_default_timezone_set('UTC');
 require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/watchnotice.php');
 
 function freshports_MainTable() {
-	GLOBAL $TableWidth;
-
-	return '<table width="' . $TableWidth . '" class="borderless">
+	return '<table class="fullwidth borderless">
 ';
 }
 
@@ -813,7 +811,6 @@ GLOBAL $ShowAnnouncements;
 }
 
 function freshports_Logo() {
-GLOBAL $TableWidth;
 GLOBAL $LocalTimeAdjustment;
 GLOBAL $FreshPortsName;
 GLOBAL $FreshPortsLogo;
@@ -824,7 +821,7 @@ GLOBAL $FreshPortsLogoHeight;
 #echo "$LocalTimeAdjustment<br>";
 
 	$HTML = '<br>
-<table width="' . $TableWidth . '" class="borderless" align="center">
+<table class="fullwidth borderless" align="center">
 <tr>
 	<td><a href="';
 
@@ -1659,12 +1656,11 @@ function freshports_UserSendToken($UserID, $dbh) {
 }
 
 function freshports_ShowFooter($PhorumBottom = 0) {
-	GLOBAL $TableWidth;
 	GLOBAL $Statistics;
 	GLOBAL $ShowPoweredBy;
 	GLOBAL $ShowAds;
 
-	$HTML = '<table width="' . $TableWidth . '" class="borderless" align="center">
+	$HTML = '<table class="fullwidth borderless" align="center">
 <tr><td>';
 
 

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -44,8 +44,6 @@ class freshports_page extends HTML_Page2 {
 		$this->addStyleSheet('/css/freshports.css?v=' . $version);
 
 		$this->addFavicon('/favicon.ico');
-
-		$this->setBodyAttributes(array('BGCOLOR' => '#FFFFFF', 'TEXT' => '#000000'));
 	}
 
 	function setDB($db) {

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -83,7 +83,6 @@ function freshports_CategoryDisplay($db, $category, $PageNumber = 1, $PageSize =
 
 #		var_dump($category);
 #
-	GLOBAL $TableWidth;
 	GLOBAL $User;
 
 	$Debug = 0;

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -13,7 +13,6 @@
 	require_once('Pager/Pager.php');
 	
 function freshports_NonPortDescription($db, $element_record) {
-	GLOBAL $TableWidth;
 	GLOBAL $FreshPortsTitle;
 
 	$Debug = 0;

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -91,7 +91,6 @@ function _freshPorts_GetPortDisplay() {
 }
 
 function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
-	GLOBAL $TableWidth;
 	GLOBAL $FreshPortsTitle;
 	GLOBAL $User;
 

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -21,11 +21,11 @@
 <TD WIDTH="100%" VALIGN="top">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <TD class="accent" HEIGHT="29"><FONT COLOR="#FFFFFF"><BIG><BIG>
+    <TD class="accent" HEIGHT="29"><BIG>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>
-</BIG></BIG></FONT></TD>
+</BIG></TD>
 </TR>
 
 <TR>

--- a/www/about.php
+++ b/www/about.php
@@ -127,7 +127,7 @@ About the Authors</A> for details of who else helped.</P>
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -82,7 +82,7 @@ if (IsSet($_REQUEST['edit'])) {
                'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <?php
 

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -106,7 +106,7 @@ echo '
 
 echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
-<TD class="accent" COLSPAN="1">' . $Title . '</TD>
+<TD class="accent" COLSPAN="1"><big>' . $Title . '</big></TD>
 </TR>
 <TR>
 <TD>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -104,9 +104,9 @@ echo '
 <br>';
 }
 
-echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
-<TD class="accent" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>' . $Title . '</BIG></BIG></FONT></TD>
+<TD class="accent" COLSPAN="1">' . $Title . '</TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -108,7 +108,7 @@ echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
 <TD class="accent" COLSPAN="1">' . $Title . '</TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo 'Current annoucements<blockquote>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -179,8 +179,8 @@ function MyDisplayAnnouncements($Announcement) {
 		$Announcement->FetchNth($i);
 		$HTML .= '<tr>' . "\n";
 		$HTML .= '<td>' . $Announcement->TextGet()      . '</td>';
-		$HTML .= '<td>' . ($Announcement->StartDateGet() != '' ? $Announcement->StartDateGet() : '&nbsp') . '</td>';
-		$HTML .= '<td>' . ($Announcement->EndDateGet()   != '' ? $Announcement->EndDateGet()   : '&nbsp') . '</td>';
+		$HTML .= '<td>' . ($Announcement->StartDateGet() != '' ? $Announcement->StartDateGet() : '&nbsp;') . '</td>';
+		$HTML .= '<td>' . ($Announcement->EndDateGet()   != '' ? $Announcement->EndDateGet()   : '&nbsp;') . '</td>';
 		$HTML .= '<td><a href="' . $_SERVER['PHP_SELF']  . '?edit='   . $Announcement->IDGet() . '">Edit</a></td>';
 		$HTML .= '<td><a href="' . $_SERVER['PHP_SELF']  . '?delete=' . $Announcement->IDGet() . '">Delete</a></td>';
       $HTML .= '</tr>' . "\n";

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -20,7 +20,7 @@
 
 ?>
 
-<TABLE width="<? echo $TableWidth ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 
 <TR><TD valign="top" width="100%">
 <TABLE class="fullwidth borderless">

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -40,7 +40,7 @@
 					'FreeBSD, index, applications, ports');
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" WIDTH="100%">
 <TABLE class="fullwidth borderless">
 

--- a/www/commits.php
+++ b/www/commits.php
@@ -77,9 +77,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -14,6 +14,8 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 .accent {
   background-color: #8c0707;
   background-color: var(--beastie-red);
+  color: white;
+  font-size: larger;
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -3,6 +3,7 @@
 }
 
 body {
+  background-color: white;
   color: black;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -2,6 +2,10 @@
   --beastie-red: #8c0707;
 }
 
+body {
+  color: black;
+}
+
 BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 {
     font-size: 12px;

--- a/www/customize.php
+++ b/www/customize.php
@@ -168,11 +168,11 @@ UPDATE users
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth bordeless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -200,12 +200,12 @@ if ($AccountModified) {
    echo "Your account details were successfully updated.";
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -174,7 +174,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -207,7 +207,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo '<p>If you wish to change your password, first type your existing password, then your new password twice.  Otherwise, leave them all blank.</p><br>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -160,7 +160,7 @@ UPDATE users
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/date.php
+++ b/www/date.php
@@ -128,7 +128,7 @@
 
 		if ($NumRows == 0) {
 			$HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
-			$HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($Date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
+			$HTML .= '   ' . FormatTime($Date, 0, "D, j M Y") . "\n";
 			$HTML .= '</TD></TR>' . "\n\n";
 			$HTML .= '<TR><TD>No commits found for that date</TD></TR>';
 		}

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -91,7 +91,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Delete Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -121,7 +121,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -85,11 +85,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Deleted Failed!</font></b></TD>
+<TR class="accent"><TD><b>Delete Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -114,12 +114,12 @@ echo '<p>If you need help, please email postmaster@. </p>
 <br>';
 }  // if ($errors)
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -77,7 +77,7 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/filter.php
+++ b/www/filter.php
@@ -63,9 +63,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -142,11 +142,11 @@ if (IsSet($submit)) {
 <?
 
 if (IsSet($error) and $error != '') {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">We have a problem!</FONT></b></TD>
+                 <TR class="accent"><TD><b>We have a problem!</b></TD>
                  </TR> 
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -169,11 +169,11 @@ if (IsSet($error) and $error != '') {
 } else {
 
    if ($LoginFailed || $eMailFailed) {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">UserID not found!</FONT></b></TD>
+                 <TR class="accent"><TD><b>UserID not found!</b></TD>
                  </TR>
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -211,12 +211,12 @@ if (IsSet($error) and $error != '') {
 }
 ?>
 
-<TABLE CELLPADDING="1" class="fullwidth borderless accent"> <TR> <TD>
+<TABLE CELLPADDING="1" class="fullwidth borderless"> <TR> <TD>
 
 
-<TABLE class="fullwidth borderless accent" CELLPADDING="5">
+<TABLE class="fullwidth borderless" CELLPADDING="5">
 
-<TR class="accent" ><TD class="accent"><FONT COLOR="#ffffff" SIZE="+2">
+<TR class="accent" ><TD class="accent">
 <?
 if ($MailSent) {
    echo "Mail sent to your address";
@@ -224,7 +224,7 @@ if ($MailSent) {
    echo "Forgotten your password?";
 }
 ?>
-</FONT></TD></TR>
+</TD></TR>
 
 <TR><TD BGCOLOR="#ffffff">
 <?

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -173,7 +173,7 @@ if (IsSet($error) and $error != '') {
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b>UserID not found!</b></TD>
+                 <TR class="accent"><TD><b>User ID not found!</b></TD>
                  </TR>
                  <TR>
             <TD>

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -148,7 +148,7 @@ if (IsSet($error) and $error != '') {
                <TABLE class="fullwidth borderless" CELLPADDING="1">
                  <TR class="accent"><TD><b>We have a problem!</b></TD>
                  </TR> 
-                 <TR BGCOLOR="#ffffff">
+                 <TR>
             <TD>
               <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN="middle">
@@ -175,7 +175,7 @@ if (IsSet($error) and $error != '') {
                <TABLE class="fullwidth borderless" CELLPADDING="1">
                  <TR class="accent"><TD><b>UserID not found!</b></TD>
                  </TR>
-                 <TR BGCOLOR="#ffffff">
+                 <TR>
             <TD>
               <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN=top>
@@ -226,7 +226,7 @@ if ($MailSent) {
 ?>
 </TD></TR>
 
-<TR><TD BGCOLOR="#ffffff">
+<TR><TD>
 <?
 if ($MailSent) {
 ?>

--- a/www/fraud/fraud.php
+++ b/www/fraud/fraud.php
@@ -11,9 +11,9 @@
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><td VALIGN=TOP>
-<TABLE WIDTH="100%" ALIGN="left" border="0">
+<TABLE class="fullwidth borderless" ALIGN="left">
 <TR>
 	<? echo freshports_PageBannerText("Fraud - This is not FreshPorts.org!"); ?>
 </TR>

--- a/www/fraud/index.php
+++ b/www/fraud/index.php
@@ -15,9 +15,9 @@
 					"FreeBSD, index, applications, ports");
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><td VALIGN=TOP>
-<TABLE WIDTH="100%" ALIGN="left" border="0">
+<TABLE class="fullwidth borderless" ALIGN="left">
 <TR>
 	<? echo freshports_PageBannerText("Fraud"); ?>
 </TR>
@@ -95,7 +95,7 @@ domain back to the registrar.
 </TABLE>
 
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/index.php
+++ b/www/index.php
@@ -81,9 +81,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -214,7 +214,7 @@ if ($db) {
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/legal.php
+++ b/www/legal.php
@@ -25,7 +25,7 @@
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">LEGAL NOTICE</FONT></TD>
+    <TD class="accent" height="32">LEGAL NOTICE</TD>
   </TR>
   <TR><TD>This page contains our obligatory legal notice.  I really don't like having to say
           these things, but given the nature of some people, I must.  For the rest of you,
@@ -33,7 +33,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">COPYRIGHT</FONT></TD>
+    <TD class="accent" height="32">COPYRIGHT</TD>
   </TR>
   <TR><TD>
   <p>Copyright <?php echo COPYRIGHTYEARS; ?> Dan Langille All rights reserved.&nbsp; Copyright in
@@ -49,7 +49,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">CONTENT AND LIABILITY DISCLAIMER</FONT></TD>
+    <TD class="accent" height="32">CONTENT AND LIABILITY DISCLAIMER</TD>
   </TR>
   <TR><TD>
   <p>Dan Langille shall not be responsible for any errors or omissions contained at
@@ -68,7 +68,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">FEEDBACK INFORMATION</FONT></TD>
+    <TD class="accent" height="32">FEEDBACK INFORMATION</TD>
   </TR>
   <TR><TD>
   <p>Any information provided to Dan Langille in connection with any Dan Langille
@@ -78,7 +78,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">TRADEMARKS</FONT></TD>
+    <TD class="accent" height="32">TRADEMARKS</TD>
   </TR>
   <TR><TD>
   <p>All Dan Langille's product names are trademarks or registered trademarks of Dan Langille

--- a/www/login.php
+++ b/www/login.php
@@ -229,7 +229,7 @@ if ($error) {
 
 echo '<TABLE class="fullwidth bordered" CELLPADDING="1">';
 
-echo '<TR class="accent">';
+echo '<TR>';
 
 echo freshports_PageBannerText("Login");
 echo '</TR>';

--- a/www/login.php
+++ b/www/login.php
@@ -169,7 +169,7 @@ if ($LoginFailed) {
 <TR>
 	<? echo freshports_PageBannerText("Login Failed!") ?>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="0">
   <TR valign=top>
@@ -204,7 +204,7 @@ if ($error) {
     <? echo freshports_PageBannerText("NOTICE"); ?>
 </TR>
 
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING=0>
   <TR valign=top>
@@ -234,7 +234,7 @@ echo '<TR class="accent">';
 echo freshports_PageBannerText("Login");
 echo '</TR>';
 
-echo '<TR><TD BGCOLOR="#ffffff">';
+echo '<TR><TD>';
 include ($_SERVER['DOCUMENT_ROOT'] . "/../include/login.php");
 
 echo "Your browser must allow cookies for this login to work.";

--- a/www/login.php
+++ b/www/login.php
@@ -227,7 +227,7 @@ if ($error) {
 
 
 
-echo '<TABLE class="fullwidth bordered accent" CELLPADDING="1">';
+echo '<TABLE class="fullwidth bordered" CELLPADDING="1">';
 
 echo '<TR class="accent">';
 

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -181,11 +181,11 @@ if (IsSet($submit)) {
 <TR><TD VALIGN="top" WIDTH="100%">
 <?php
 if ($errors != '') {
-echo '<TABLE CELLPADDING=1 class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING=1 class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING=1>
-<TR class="accent"><TD><B><FONT color="#ffffff" size=+0>Access Code Failed!</FONT></B></TD>
+<TR class="accent"><TD><B>Access Code Failed!</B></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -187,7 +187,7 @@ echo '<TABLE CELLPADDING=1 class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING=1>
 <TR class="accent"><TD><B>Access Code Failed!</B></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING=3>
   <TR VALIGN=top>

--- a/www/package.php
+++ b/www/package.php
@@ -70,7 +70,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -109,7 +109,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -144,7 +144,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo '<p>Please enter your new password twice.</p><br>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -103,11 +103,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -137,12 +137,12 @@ if ($PasswordReset) {
 
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Reset password via token</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -95,7 +95,7 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/pkg_process.inc
+++ b/www/pkg_process.inc
@@ -48,7 +48,7 @@ function DisplayError($error) {
 			    <? echo freshports_PageBannerText("NOTICE"); ?>
 			</TR>
 
-			<TR BGCOLOR="#ffffff">
+			<TR>
 				<TD>
 					<TABLE class="fullwidth borderless" CELLPADDING="0">
 						<TR VALIGN="top">

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -211,7 +211,7 @@ needed.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -202,7 +202,7 @@ the following fields.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -146,7 +146,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG><? echo $ArticleTitle; ?></BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG><? echo $ArticleTitle; ?></BIG></TD>
 </TR>
 <TR>
 <TD>

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -44,9 +44,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -214,7 +214,7 @@ since 10 October 2006.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';


### PR DESCRIPTION
More work removing deprecated HTML markup.

- Minor A element fixes
- Migrate some attributes to CSS
- Minor HTML syntax fixes

Curious to see the fallout from this one, if any!
Things to look out for:
- Tables with red header bars having text disappear (font accidentally changing all white)
- Table header text changing size from the old version (hopefully the new sizing is actually a bit more consistent, but we'll see how it goes)
- Tables turning red now that their rows don't have the BG explicitly set back to white (I *think* this shouldn't be possible now, though)

This doesn't remove all the `<big>` tags yet, since there's some nesting and it's not entirely consistent, so just doing the outer levels for now.

Let me know if anything missed or other issues, and thanks for your time testing & reviewing!