### PR TITLE
HTML Cleanup: Table attributes

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -145,9 +145,9 @@ class DisplayCommit {
 				$MaxNumberPortsToShow      = 10;
 
 				if ($mycommit->commit_date != $PreviousCommit->commit_date) {
-					$this->HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
+					$this->HTML .= '<tr><td class="accent">' . "\n";
 					$this->HTML .= '   ' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . "\n";
-					$this->HTML .= '</TD></TR>' . "\n\n";
+					$this->HTML .= "</td></tr>\n\n";
 				}
 
 				GLOBAL $freshports_mail_archive;

--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -190,8 +190,8 @@ class DisplayCommit {
 					
 				if ($mycommit->svn_revision != '') {
 					if ($this->IsGitCommit($mycommit->message_id)) {
-						$this->HTML .= '&nbsp; ' .       freshports_git_commit_Link($mycommit->svn_revision,                               $mycommit->repo_hostname, $mycommit->path_to_repo);
-						$this->HTML .= '&nbsp; ' .  freshports_git_commit_Link_Hash($mycommit->svn_revision, $mycommit->commit_hash_short, $mycommit->repo_hostname, $mycommit->path_to_repo). '&nbsp';
+						$this->HTML .= '&nbsp; ' .      freshports_git_commit_Link($mycommit->svn_revision,                               $mycommit->repo_hostname, $mycommit->path_to_repo);
+						$this->HTML .= '&nbsp; ' . freshports_git_commit_Link_Hash($mycommit->svn_revision, $mycommit->commit_hash_short, $mycommit->repo_hostname, $mycommit->path_to_repo) . '&nbsp;';
 					} else {
 						$this->HTML .= '&nbsp; ' . freshports_svnweb_ChangeSet_Link($mycommit->svn_revision, $mycommit->repo_hostname);
 					}

--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -146,7 +146,7 @@ class DisplayCommit {
 
 				if ($mycommit->commit_date != $PreviousCommit->commit_date) {
 					$this->HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
-					$this->HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
+					$this->HTML .= '   ' . FormatTime($mycommit->commit_date, 0, "D, j M Y") . "\n";
 					$this->HTML .= '</TD></TR>' . "\n\n";
 				}
 

--- a/classes/files-display.php
+++ b/classes/files-display.php
@@ -24,7 +24,6 @@ class FilesDisplay {
 	}
 
 	function CreateHTML($WhichRepo) {
-		GLOBAL $TableWidth;
 		GLOBAL $freshports_CommitMsgMaxNumOfLinesToShow;
 		GLOBAL $DaysMarkedAsNew;
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1933,7 +1933,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<th COLSPAN="2" class="accent" height="30">Statistics</th>
+		<th class="accent" height="30">Statistics</th>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1750,10 +1750,9 @@ urchinTracker();
 function freshports_SideBar() {
 
 	GLOBAL $User;
-	$ColumnWidth = 160;
 
 	$HTML = '
-  <table width="' . $ColumnWidth . '" class="bordered">
+  <table class="bordered">
         <tr>
          <th class="accent">Login</th>
         </tr>
@@ -1802,12 +1801,12 @@ function freshports_SideBar() {
 </div>';
 
 	$HTML .= '	
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">This site</th>
 	</tr>
 	<tr>
-	<td valign="top">
+	<td>
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"               ) . '
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                           ) . '
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES,                 "Issues",              "Report a website problem"                        ) . '
@@ -1821,7 +1820,7 @@ function freshports_SideBar() {
 	</tr>
 </table>
 <br>
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">Search</th>
 	</tr>
@@ -1845,7 +1844,7 @@ function freshports_SideBar() {
 ';
 	if (file_exists(HTML_DIRECTORY . '/vuln-latest.html')) {
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">Latest Vulnerabilities</th>
 	</tr>
@@ -1864,12 +1863,12 @@ $HTML .= '<br>
 
 	$HTML .= '
 
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">Ports</th>
 	</tr>
 	<tr>
-	<td valign="top">
+	<td>
 
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                         "Home",                 "FreshPorts Home page"                ) . '
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",           "Categories",           "List of all Port categories"         ) . '
@@ -1886,12 +1885,12 @@ if (IsSet($visitor)) {
 
 
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">Watch Lists</th>
 	</tr>
 	<tr>
-	<td valign="top">';
+	<td>';
 
 		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/pkg_upload.php',             "Upload",               "Upoad a file containing a list of ports you want to add to your watch list");
 		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-categories.php',       "Categories",           "Search through categories for ports to add to your watch list"             );
@@ -1921,12 +1920,12 @@ $HTML .= '
 
 	$HTML .= '<br>
 
-<table width="' . $ColumnWidth . '" class="bordered">
+<table class="bordered">
 	<tr>
 		<th class="accent">Statistics</th>
 	</tr>
 	<tr>
-	<td valign="top">
+	<td>
 
 ' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",  "Graphs",                  "Everyone loves statistics!") . '
 ' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php", "NEW Graphs (Javascript)", "Everyone loves statistics!");

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1929,8 +1929,7 @@ $HTML .= '
 	<td valign="top">
 
 ' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",  "Graphs",                  "Everyone loves statistics!") . '<br>
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php", "NEW Graphs (Javascript)", "Everyone loves statistics!") . '<br>
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/stats/",      "Traffic",                 "Traffic to this website"   );
+' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php", "NEW Graphs (Javascript)", "Everyone loves statistics!");
 
 	if (file_exists(HTML_DIRECTORY . '/stats.html')) {
 		$HTML .= '<br>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -821,7 +821,7 @@ GLOBAL $FreshPortsLogoHeight;
 #echo "$LocalTimeAdjustment<br>";
 
 	$HTML = '<br>
-<table class="fullwidth borderless" align="center">
+<table class="fullwidth borderless">
 <tr>
 	<td><a href="';
 
@@ -1589,7 +1589,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
+	return '<td class="accent" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
 }
 
 
@@ -1650,7 +1650,7 @@ function freshports_ShowFooter($PhorumBottom = 0) {
 	GLOBAL $ShowPoweredBy;
 	GLOBAL $ShowAds;
 
-	$HTML = '<table class="fullwidth borderless" align="center">
+	$HTML = '<table class="footer fullwidth borderless">
 <tr><td>';
 
 
@@ -1703,10 +1703,10 @@ alt="powered by nginx" width="121" height="32"></a>
 <tr><td>
 <table class="fullwidth">
 <tr>
-<td align="left"  valign="top">
+<td class="sponsors">
 <small>' . SPONSORS . '</small>
 </td>
-<td align="right" valign="top">
+<td class="copyright">
 <small>
 Valid 
 <a href="https://validator.w3.org/check?uri=' . $URI . '" title="We like to keep our HTML valid" target="_blank" rel="noopener noreferrer">HTML</a>,

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1589,7 +1589,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
+	return '<td align="left" class="accent" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
 }
 
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -976,7 +976,7 @@ function freshports_body($ExtraScript = null) {
 
 GLOBAL $Debug;
 
-echo "\n" . '<BODY bgcolor="#FFFFFF" TEXT="#000000">';
+echo "\n" . '<BODY bgcolor="#FFFFFF">';
 
 # most often used for page setup, hiding elements, etc
 if (!empty($ExtraScript)) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1755,7 +1755,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered">
         <tr>
-         <th class="accent" height="30">Login</th>
+         <th class="accent">Login</th>
         </tr>
         <tr>
 
@@ -1804,7 +1804,7 @@ function freshports_SideBar() {
 	$HTML .= '	
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">This site</th>
+		<th class="accent">This site</th>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1823,7 +1823,7 @@ function freshports_SideBar() {
 <br>
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">Search</th>
+		<th class="accent">Search</th>
 	</tr>
 	<tr>
 
@@ -1847,7 +1847,7 @@ function freshports_SideBar() {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">Latest Vulnerabilities</th>
+		<th class="accent">Latest Vulnerabilities</th>
 	</tr>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
@@ -1866,7 +1866,7 @@ $HTML .= '<br>
 
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">Ports</th>
+		<th class="accent">Ports</th>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1888,7 +1888,7 @@ if (IsSet($visitor)) {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">Watch Lists</th>
+		<th class="accent">Watch Lists</th>
 	</tr>
 	<tr>
 	<td valign="top">';
@@ -1923,7 +1923,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
-		<th class="accent" height="30">Statistics</th>
+		<th class="accent">Statistics</th>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1785,18 +1785,18 @@ function freshports_SideBar() {
 			$HTML .= '<FONT SIZE="-1">your email is <a href="/bouncing.php">bouncing</a></FONT><br>';
 			$HTML .= '<img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><br>';
 		}
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/customize.php',        "", "Your Account", "Your account"              ) . '</FONT><br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/customize.php',        "", "Your Account", "Your account"              ) . '<br>';
 
 		if (preg_match("/.*@FreeBSD.org/i", $User->email)) {
-			$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/committer-opt-in.php', '', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures"       ) . '</FONT><br>';
+			$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/committer-opt-in.php', '', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures"       ) . '<br>';
 		}
 
 
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/logout.php',                 '', "Logout",                  "Logout of the website"                  ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/my-flagged-commits.php',     '', "My Flagged Commits",      "List of commits you have flagged"       ) . '</FONT><br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/logout.php',                 '', "Logout",                  "Logout of the website"                  ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/my-flagged-commits.php',     '', "My Flagged Commits",      "List of commits you have flagged"       ) . '<br>';
 	} else {
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/login.php',                  "", "User Login",              "Login to the website"                   ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/new-user.php',               "", "Create account",          "Create an account"                      ) . '</FONT><br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/login.php',                  "", "User Login",              "Login to the website"                   ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/new-user.php',               "", "Create account",          "Create an account"                      ) . '<br>';
 	}
 
 	$HTML .= '
@@ -1818,15 +1818,15 @@ function freshports_SideBar() {
 	</tr>
 	<tr>
 	<td valign="top">
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"    ) . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                ) . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES       ,          "Issues",              "Report a website problem"             ) . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"           ) . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"  ) . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/security-policy.php", "Security Policy",     "Are you a security researcher? Please read this.") . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                ) . '</FONT><br>
-	<FONT SIZE="-1"><a href="https://news.freshports.org/" title="All the latest FreshPorts news" rel="noopener noreferrer">Blog</a></FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                      ) . '</FONT><br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"    ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES       ,          "Issues",              "Report a website problem"             ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"           ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"  ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/security-policy.php", "Security Policy",     "Are you a security researcher? Please read this.") . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                ) . '<br>
+	<a href="https://news.freshports.org/" title="All the latest FreshPorts news" rel="noopener noreferrer">Blog</a><br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                      ) . '<br>
 	</td>
 	</tr>
 </table>
@@ -1847,7 +1847,7 @@ function freshports_SideBar() {
 	$Searches = new Searches($dbh);
 	$HTML .= $Searches->GetFormSimple('&nbsp;');
 
-	$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/search.php', '', "more...", "Advanced Searching options") . '</FONT><br>
+	$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/search.php', '', "more...", "Advanced Searching options") . '<br>
 	</td>
 </tr>
 </table>
@@ -1881,11 +1881,11 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">
 
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                     "Home",             "FreshPorts Home page"       )   . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",       "Categories",       "List of all Port categories")   . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",    "Deleted ports",    "All deleted ports"          )   . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php",    "Sanity Test Failures",    "Things that didn't go quite right..."          )   . '</FONT><br>
-	<FONT SIZE="-1">' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",    "Newsfeeds for just about everything"          )   . '</FONT><br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                     "Home",             "FreshPorts Home page"       )   . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",       "Categories",       "List of all Port categories")   . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",    "Deleted ports",    "All deleted ports"          )   . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php",    "Sanity Test Failures",    "Things that didn't go quite right..."          )   . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",    "Newsfeeds for just about everything"          )   . '<br>
 	
 	</td>
 	</tr>
@@ -1903,12 +1903,12 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">';
 
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/pkg_upload.php',             '',                     "Upload",               "Upoad a file containing a list of ports you want to add to your watch list") . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-categories.php',       '',                     "Categories",           "Search through categories for ports to add to your watch list"             ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', '',                     "Maintain",             "Maintain your watch list[s]"                                               ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch.php',                  '',                     "Ports",                "Your list of watched ports"                                                ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/backend/watch-list.php',     '',                     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               ) . '</FONT><br>';
-		$HTML .= '<FONT SIZE="-1">' . freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/report-subscriptions.php',   '',                     "Report Subscriptions", "Maintain your list of subscriptions"                                       ) . '</FONT><br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/pkg_upload.php',             '',                     "Upload",               "Upoad a file containing a list of ports you want to add to your watch list") . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-categories.php',       '',                     "Categories",           "Search through categories for ports to add to your watch list"             ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', '',                     "Maintain",             "Maintain your watch list[s]"                                               ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch.php',                  '',                     "Ports",                "Your list of watched ports"                                                ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/backend/watch-list.php',     '',                     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               ) . '<br>';
+		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/report-subscriptions.php',   '',                     "Report Subscriptions", "Maintain your list of subscriptions"                                       ) . '<br>';
 
 $HTML .= '		
 	</td>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1086,7 +1086,7 @@ function freshports_SideBarHTML($Self, $URL, $Label, $Title) {
       $HTML = '<a href="' . $URL . '" title="' . $Title . '">' . $Label . '</a>';
    }
 
-   return $HTML;
+   return $HTML . '<br>';
 }
 
 function freshports_YNToCheckbox($Value) {
@@ -1768,25 +1768,25 @@ function freshports_SideBar() {
 	if (IsSet($visitor)) {
 		GLOBAL $User;
 
-		$HTML .= '<FONT SIZE="-1">Logged in as ' . htmlentities($User->name) . "</FONT><br>";
+		$HTML .= 'Logged in as ' . htmlentities($User->name) . "<br>";
 
 		if ($User->emailbouncecount > 0) {
 			$HTML .= '<img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif"  border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><br>';
-			$HTML .= '<FONT SIZE="-1">your email is <a href="/bouncing.php">bouncing</a></FONT><br>';
+			$HTML .= 'your email is <a href="/bouncing.php">bouncing</a><br>';
 			$HTML .= '<img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><br>';
 		}
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/customize.php', "Your Account", "Your account") . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/customize.php', "Your Account", "Your account");
 
 		if (preg_match("/.*@FreeBSD.org/i", $User->email)) {
-			$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/committer-opt-in.php', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures") . '<br>';
+			$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/committer-opt-in.php', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures");
 		}
 
 
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/logout.php',             "Logout",                  "Logout of the website"            ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/my-flagged-commits.php', "My Flagged Commits",      "List of commits you have flagged" ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/logout.php',             "Logout",                  "Logout of the website"            );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/my-flagged-commits.php', "My Flagged Commits",      "List of commits you have flagged" );
 	} else {
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/login.php',              "User Login",              "Login to the website"             ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/new-user.php',           "Create account",          "Create an account"                ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/login.php',              "User Login",              "Login to the website"             );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/new-user.php',           "Create account",          "Create an account"                );
 	}
 
 	$HTML .= '
@@ -1808,15 +1808,15 @@ function freshports_SideBar() {
 	</tr>
 	<tr>
 	<td valign="top">
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"               ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                           ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES,                 "Issues",              "Report a website problem"                        ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"                      ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"             ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/security-policy.php", "Security Policy",     "Are you a security researcher? Please read this.") . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                           ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"               ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                           ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES,                 "Issues",              "Report a website problem"                        ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"                      ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"             ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/security-policy.php", "Security Policy",     "Are you a security researcher? Please read this.") . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                           ) . '
 	<a href="https://news.freshports.org/" title="All the latest FreshPorts news" rel="noopener noreferrer">Blog</a><br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                                 ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                                 ) . '
 	</td>
 	</tr>
 </table>
@@ -1837,7 +1837,7 @@ function freshports_SideBar() {
 	$Searches = new Searches($dbh);
 	$HTML .= $Searches->GetFormSimple('&nbsp;');
 
-	$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/search.php', "more...", "Advanced Searching options") . '<br>
+	$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/search.php', "more...", "Advanced Searching options") . '
 	</td>
 </tr>
 </table>
@@ -1871,11 +1871,11 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">
 
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                         "Home",                 "FreshPorts Home page"                ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",           "Categories",           "List of all Port categories"         ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",        "Deleted ports",        "All deleted ports"                   ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php", "Sanity Test Failures", "Things that didn't go quite right...") . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",            "Newsfeeds for just about everything" ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                         "Home",                 "FreshPorts Home page"                ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",           "Categories",           "List of all Port categories"         ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",        "Deleted ports",        "All deleted ports"                   ) . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php", "Sanity Test Failures", "Things that didn't go quite right...") . '
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",            "Newsfeeds for just about everything" ) . '
 	
 	</td>
 	</tr>
@@ -1893,12 +1893,12 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">';
 
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/pkg_upload.php',             "Upload",               "Upoad a file containing a list of ports you want to add to your watch list") . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-categories.php',       "Categories",           "Search through categories for ports to add to your watch list"             ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', "Maintain",             "Maintain your watch list[s]"                                               ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch.php',                  "Ports",                "Your list of watched ports"                                                ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/backend/watch-list.php',     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               ) . '<br>';
-		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/report-subscriptions.php',   "Report Subscriptions", "Maintain your list of subscriptions"                                       ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/pkg_upload.php',             "Upload",               "Upoad a file containing a list of ports you want to add to your watch list");
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-categories.php',       "Categories",           "Search through categories for ports to add to your watch list"             );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', "Maintain",             "Maintain your watch list[s]"                                               );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch.php',                  "Ports",                "Your list of watched ports"                                                );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/backend/watch-list.php',     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               );
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/report-subscriptions.php',   "Report Subscriptions", "Maintain your list of subscriptions"                                       );
 
 $HTML .= '		
 	</td>
@@ -1928,12 +1928,11 @@ $HTML .= '
 	<tr>
 	<td valign="top">
 
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",  "Graphs",                  "Everyone loves statistics!") . '<br>
+' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",  "Graphs",                  "Everyone loves statistics!") . '
 ' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php", "NEW Graphs (Javascript)", "Everyone loves statistics!");
 
 	if (file_exists(HTML_DIRECTORY . '/stats.html')) {
-		$HTML .= '<br>
-' . file_get_contents(HTML_DIRECTORY . '/stats.html') . "\n";
+		$HTML .= file_get_contents(HTML_DIRECTORY . '/stats.html') . "\n";
 	}
 
 	$HTML .= '

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1599,7 +1599,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '">' . $Text . '</td>' . "\n";
+	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
 }
 
 
@@ -1765,7 +1765,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td class="accent" height="30"><b>Login</b></FONT></td>
+         <td class="accent" height="30"><b>Login</b></td>
         </tr>
         <tr>
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -973,7 +973,7 @@ function freshports_body($ExtraScript = null) {
 
 GLOBAL $Debug;
 
-echo "\n" . '<BODY bgcolor="#FFFFFF">';
+echo "\n" . '<BODY>';
 
 # most often used for page setup, hiding elements, etc
 if (!empty($ExtraScript)) {
@@ -1984,7 +1984,7 @@ function freshports_ErrorMessage($Title, $ErrorMessage) {
 <tr>
 	' . freshports_PageBannerText($Title) . '
 </tr>
-<tr bgcolor="#ffffff">
+<tr>
 <td>
   <table class="fullwidth borderless" cellpadding="0">
   <tr valign=top>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -499,7 +499,7 @@ function freshports_Ignore_Icon($HoverText = '') {
 	$Alt       = "Ignore";
 	$HoverText = freshports_HoverTextCleaner($Alt, $HoverText);
 
-	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="21;">';
+	return '<img src="/images/ignored.png" alt="' . $Alt . '" title="' . $HoverText . '" width="20" height="21">';
 }
 
 function freshports_Ignore_Icon_Link($HoverText = '') {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1090,13 +1090,7 @@ function freshports_SideBarHTML($Self, $URL, $Label, $Title) {
 }
 
 function freshports_SideBarHTMLParm($Self, $URL, $Parm, $Label, $Title) {
-   if ($Self == $URL || ($Self == '/index.php' && $URL == '/')) {
-      $HTML = $Label;
-   } else {
-      $HTML = '<a href="' . $URL . $Parm . '" title="' . $Title . '">' . $Label . '</a>';
-   }
-      
-   return $HTML;
+   return freshPorts_SideBarHTML($Self, $URL . $Parm, $Label, $Title);
 }
 
 function freshports_YNToCheckbox($Value) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1804,7 +1804,7 @@ function freshports_SideBar() {
    </tr>
    </table>
 
-' . '<div align="center">';
+' . '<div>';
 
 	$HTML .='
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1599,7 +1599,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '"><FONT COLOR="#FFFFFF"><big><big>' . $Text . '</big></big></FONT></td>' . "\n";
+	return '<td align="left" class="accent" height="29" COLSPAN="' . $ColSpan . '">' . $Text . '</td>' . "\n";
 }
 
 
@@ -1765,7 +1765,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Login</b></big></FONT></td>
+         <td class="accent" height="30"><b>Login</b></FONT></td>
         </tr>
         <tr>
 
@@ -1814,7 +1814,7 @@ function freshports_SideBar() {
 	$HTML .= '	
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>This site</b></big></FONT></td>
+		<td class="accent" height="30"><b>This site</b></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1833,7 +1833,7 @@ function freshports_SideBar() {
 <br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Search</b></big></FONT></td>
+		<td class="accent" height="30"><b>Search</b></td>
 	</tr>
 	<tr>
 
@@ -1857,7 +1857,7 @@ function freshports_SideBar() {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Latest Vulnerabilities</b></big></FONT></td>
+		<td class="accent" height="30"><b>Latest Vulnerabilities</b></td>
 	</tr>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
@@ -1876,7 +1876,7 @@ $HTML .= '<br>
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Ports</b></big></FONT></td>
+		<td class="accent" height="30"><b>Ports</b></td>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1898,7 +1898,7 @@ if (IsSet($visitor)) {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Watch Lists</b></big></FONT></td>
+		<td class="accent" height="30"><b>Watch Lists</b></td>
 	</tr>
 	<tr>
 	<td valign="top">';
@@ -1933,7 +1933,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td COLSPAN="2" class="accent" height="30"><FONT COLOR="#FFFFFF"><big><b>Statistics</b></big></FONT></td>
+		<td COLSPAN="2" class="accent" height="30"><b>Statistics</b></td>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1089,10 +1089,6 @@ function freshports_SideBarHTML($Self, $URL, $Label, $Title) {
    return $HTML;
 }
 
-function freshports_SideBarHTMLParm($Self, $URL, $Parm, $Label, $Title) {
-   return freshPorts_SideBarHTML($Self, $URL . $Parm, $Label, $Title);
-}
-
 function freshports_YNToCheckbox($Value) {
 // this function takes a Y/N value and converts it to
 // HTML suitable for a checkbox.
@@ -1779,18 +1775,18 @@ function freshports_SideBar() {
 			$HTML .= '<FONT SIZE="-1">your email is <a href="/bouncing.php">bouncing</a></FONT><br>';
 			$HTML .= '<img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><img src="/images/warning.gif" border="0" height="32" width="32"><br>';
 		}
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/customize.php',        "", "Your Account", "Your account"              ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/customize.php', "Your Account", "Your account") . '<br>';
 
 		if (preg_match("/.*@FreeBSD.org/i", $User->email)) {
-			$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/committer-opt-in.php', '', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures"       ) . '<br>';
+			$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/committer-opt-in.php', "Committer Opt-in", "Committers can receive reports of Sanity Test Failures") . '<br>';
 		}
 
 
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/logout.php',                 '', "Logout",                  "Logout of the website"                  ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/my-flagged-commits.php',     '', "My Flagged Commits",      "List of commits you have flagged"       ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/logout.php',             "Logout",                  "Logout of the website"            ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/my-flagged-commits.php', "My Flagged Commits",      "List of commits you have flagged" ) . '<br>';
 	} else {
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/login.php',                  "", "User Login",              "Login to the website"                   ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/new-user.php',               "", "Create account",          "Create an account"                      ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/login.php',              "User Login",              "Login to the website"             ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/new-user.php',           "Create account",          "Create an account"                ) . '<br>';
 	}
 
 	$HTML .= '
@@ -1812,15 +1808,15 @@ function freshports_SideBar() {
 	</tr>
 	<tr>
 	<td valign="top">
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"    ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES       ,          "Issues",              "Report a website problem"             ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"           ) . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"  ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/about.php",           "What is FreshPorts?", "A bit of background on FreshPorts"               ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/authors.php",         "About the authors",   "Who wrote this stuff?"                           ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], ISSUES,                 "Issues",              "Report a website problem"                        ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/faq.php",             "FAQ",                 "Frequently Asked Questions"                      ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/how-big-is-it.php",   "How big is it?",      "How many pages are in this website?"             ) . '<br>
 	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/security-policy.php", "Security Policy",     "Are you a security researcher? Please read this.") . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/privacy.php",         "Privacy",             "Our privacy statement"                           ) . '<br>
 	<a href="https://news.freshports.org/" title="All the latest FreshPorts news" rel="noopener noreferrer">Blog</a><br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                      ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/contact.php",         "Contact",             "Contact details"                                 ) . '<br>
 	</td>
 	</tr>
 </table>
@@ -1841,7 +1837,7 @@ function freshports_SideBar() {
 	$Searches = new Searches($dbh);
 	$HTML .= $Searches->GetFormSimple('&nbsp;');
 
-	$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/search.php', '', "more...", "Advanced Searching options") . '<br>
+	$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/search.php', "more...", "Advanced Searching options") . '<br>
 	</td>
 </tr>
 </table>
@@ -1875,11 +1871,11 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">
 
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                     "Home",             "FreshPorts Home page"       )   . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",       "Categories",       "List of all Port categories")   . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",    "Deleted ports",    "All deleted ports"          )   . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php",    "Sanity Test Failures",    "Things that didn't go quite right..."          )   . '<br>
-	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",    "Newsfeeds for just about everything"          )   . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/",                         "Home",                 "FreshPorts Home page"                ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/categories.php",           "Categories",           "List of all Port categories"         ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/ports-deleted.php",        "Deleted ports",        "All deleted ports"                   ) . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/sanity_test_failures.php", "Sanity Test Failures", "Things that didn't go quite right...") . '<br>
+	' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/backend/newsfeeds.php",    "Newsfeeds",            "Newsfeeds for just about everything" ) . '<br>
 	
 	</td>
 	</tr>
@@ -1897,12 +1893,12 @@ $HTML .= '<br>
 	<tr>
 	<td valign="top">';
 
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/pkg_upload.php',             '',                     "Upload",               "Upoad a file containing a list of ports you want to add to your watch list") . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-categories.php',       '',                     "Categories",           "Search through categories for ports to add to your watch list"             ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', '',                     "Maintain",             "Maintain your watch list[s]"                                               ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/watch.php',                  '',                     "Ports",                "Your list of watched ports"                                                ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/backend/watch-list.php',     '',                     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               ) . '<br>';
-		$HTML .= freshports_SideBarHTMLParm($_SERVER["PHP_SELF"], '/report-subscriptions.php',   '',                     "Report Subscriptions", "Maintain your list of subscriptions"                                       ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/pkg_upload.php',             "Upload",               "Upoad a file containing a list of ports you want to add to your watch list") . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-categories.php',       "Categories",           "Search through categories for ports to add to your watch list"             ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch-list-maintenance.php', "Maintain",             "Maintain your watch list[s]"                                               ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/watch.php',                  "Ports",                "Your list of watched ports"                                                ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/backend/watch-list.php',     "Personal Newsfeeds",   "A list of news feeds for your watched lists"                               ) . '<br>';
+		$HTML .= freshports_SideBarHTML($_SERVER["PHP_SELF"], '/report-subscriptions.php',   "Report Subscriptions", "Maintain your list of subscriptions"                                       ) . '<br>';
 
 $HTML .= '		
 	</td>
@@ -1932,9 +1928,9 @@ $HTML .= '
 	<tr>
 	<td valign="top">
 
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",        "Graphs", "Everyone loves statistics!")   . '<br>
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php",        "NEW Graphs (Javascript)", "Everyone loves statistics!")   . '<br>
-' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/stats/",            "Traffic", "Traffic to this website");
+' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs.php",  "Graphs",                  "Everyone loves statistics!") . '<br>
+' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/graphs2.php", "NEW Graphs (Javascript)", "Everyone loves statistics!") . '<br>
+' . freshports_SideBarHTML($_SERVER["PHP_SELF"], "/stats/",      "Traffic",                 "Traffic to this website"   );
 
 	if (file_exists(HTML_DIRECTORY . '/stats.html')) {
 		$HTML .= '<br>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -29,7 +29,7 @@ DEFINE('UNMAINTAINTED_ADDRESS', 'ports@freebsd.org');
 
 DEFINE('CLICKTOADD', 'Click to add this to your default watch list[s]');
 
-DEFINE('SPONSORS', 'Servers and bandwidth provided by<br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_new">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_new">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_new">RootBSD</a>');
+DEFINE('SPONSORS', 'Servers and bandwidth provided by<br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_blank">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_blank">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_blank">RootBSD</a>');
 
 DEFINE('FRESHPORTS_ENCODING', 'UTF-8');
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1765,7 +1765,7 @@ function freshports_SideBar() {
 	$HTML = '
   <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
         <tr>
-         <td class="accent" height="30"><b>Login</b></td>
+         <th class="accent" height="30">Login</th>
         </tr>
         <tr>
 
@@ -1814,7 +1814,7 @@ function freshports_SideBar() {
 	$HTML .= '	
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><b>This site</b></td>
+		<th class="accent" height="30">This site</th>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1833,7 +1833,7 @@ function freshports_SideBar() {
 <br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><b>Search</b></td>
+		<th class="accent" height="30">Search</th>
 	</tr>
 	<tr>
 
@@ -1857,7 +1857,7 @@ function freshports_SideBar() {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><b>Latest Vulnerabilities</b></td>
+		<th class="accent" height="30">Latest Vulnerabilities</th>
 	</tr>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
@@ -1876,7 +1876,7 @@ $HTML .= '<br>
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><b>Ports</b></td>
+		<th class="accent" height="30">Ports</th>
 	</tr>
 	<tr>
 	<td valign="top">
@@ -1898,7 +1898,7 @@ if (IsSet($visitor)) {
 $HTML .= '<br>
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td class="accent" height="30"><b>Watch Lists</b></td>
+		<th class="accent" height="30">Watch Lists</th>
 	</tr>
 	<tr>
 	<td valign="top">';
@@ -1933,7 +1933,7 @@ $HTML .= '
 
 <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
 	<tr>
-		<td COLSPAN="2" class="accent" height="30"><b>Statistics</b></td>
+		<th COLSPAN="2" class="accent" height="30">Statistics</th>
 	</tr>
 	<tr>
 	<td valign="top">

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -40,9 +40,7 @@ date_default_timezone_set('UTC');
 require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/watchnotice.php');
 
 function freshports_MainTable() {
-	GLOBAL $TableWidth;
-
-	return '<table width="' . $TableWidth . '" class="borderless">
+	return '<table class="fullwidth borderless">
 ';
 }
 
@@ -813,7 +811,6 @@ GLOBAL $ShowAnnouncements;
 }
 
 function freshports_Logo() {
-GLOBAL $TableWidth;
 GLOBAL $LocalTimeAdjustment;
 GLOBAL $FreshPortsName;
 GLOBAL $FreshPortsLogo;
@@ -824,7 +821,7 @@ GLOBAL $FreshPortsLogoHeight;
 #echo "$LocalTimeAdjustment<br>";
 
 	$HTML = '<br>
-<table width="' . $TableWidth . '" class="borderless" align="center">
+<table class="fullwidth borderless" align="center">
 <tr>
 	<td><a href="';
 
@@ -1659,12 +1656,11 @@ function freshports_UserSendToken($UserID, $dbh) {
 }
 
 function freshports_ShowFooter($PhorumBottom = 0) {
-	GLOBAL $TableWidth;
 	GLOBAL $Statistics;
 	GLOBAL $ShowPoweredBy;
 	GLOBAL $ShowAds;
 
-	$HTML = '<table width="' . $TableWidth . '" class="borderless" align="center">
+	$HTML = '<table class="fullwidth borderless" align="center">
 <tr><td>';
 
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -136,7 +136,7 @@ function freshports_Search_Committer($Committer) {
 }
 
 function freshports_MainContentTable($Classes=BORDER, $ColSpan=1) {
-	return '<table class="fullwidth ' . $Classes . '" cellpadding="8">' . 
+	return '<table class="maincontent fullwidth ' . $Classes . '">' .
 		PortsFreezeStatus($ColSpan);
 }
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1753,7 +1753,7 @@ function freshports_SideBar() {
 	$ColumnWidth = 160;
 
 	$HTML = '
-  <table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+  <table width="' . $ColumnWidth . '" class="bordered">
         <tr>
          <th class="accent" height="30">Login</th>
         </tr>
@@ -1802,7 +1802,7 @@ function freshports_SideBar() {
 </div>';
 
 	$HTML .= '	
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">This site</th>
 	</tr>
@@ -1821,7 +1821,7 @@ function freshports_SideBar() {
 	</tr>
 </table>
 <br>
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">Search</th>
 	</tr>
@@ -1845,7 +1845,7 @@ function freshports_SideBar() {
 ';
 	if (file_exists(HTML_DIRECTORY . '/vuln-latest.html')) {
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">Latest Vulnerabilities</th>
 	</tr>
@@ -1864,7 +1864,7 @@ $HTML .= '<br>
 
 	$HTML .= '
 
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">Ports</th>
 	</tr>
@@ -1886,7 +1886,7 @@ if (IsSet($visitor)) {
 
 
 $HTML .= '<br>
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">Watch Lists</th>
 	</tr>
@@ -1910,7 +1910,7 @@ $HTML .= '
 	GLOBAL $ShowAds;
 
 	if ($ShowAds) {
-		$HTML .= '<br><table class="borderless" cellpadding="5">
+		$HTML .= '<br><table class="borderless">
 		  <tr><td align="center">
 		';
 		$HTML .= Ad_160x600();
@@ -1921,7 +1921,7 @@ $HTML .= '
 
 	$HTML .= '<br>
 
-<table width="' . $ColumnWidth . '" class="bordered" cellpadding="5">
+<table width="' . $ColumnWidth . '" class="bordered">
 	<tr>
 		<th class="accent" height="30">Statistics</th>
 	</tr>

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -67,7 +67,7 @@ class freshports_page extends HTML_Page2 {
 			}
 		}
 
-		$HTML .= freshports_MainTable() . "\n<tr><td width='100%' valign='top'>\n" .
+		$HTML .= freshports_MainTable() . "\n<tr><td class=\"content\">\n" .
 		         freshports_MainContentTable() . "\n<tr>\n" .
 		         freshports_PageBannerText($this->_title);
 

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -73,7 +73,7 @@ class freshports_page extends HTML_Page2 {
 
 		$this->prependBodyContent($HTML);
 
-		$this->addBodyContent("\n</table><td class=\"sidebar\" valign=\"top\">" . freshports_SideBar() . "</td></tr></table>\n" . freshports_ShowFooter());
+		$this->addBodyContent("\n</table><td class=\"sidebar\">" . freshports_SideBar() . "</td></tr></table>\n" . freshports_ShowFooter());
 
 		return parent::toHTML();
 	}

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -44,8 +44,6 @@ class freshports_page extends HTML_Page2 {
 		$this->addStyleSheet('/css/freshports.css?v=' . $version);
 
 		$this->addFavicon('/favicon.ico');
-
-		$this->setBodyAttributes(array('BGCOLOR' => '#FFFFFF', 'TEXT' => '#000000'));
 	}
 
 	function setDB($db) {

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -73,7 +73,7 @@ class freshports_page extends HTML_Page2 {
 
 		$this->prependBodyContent($HTML);
 
-		$this->addBodyContent("\n</table><td valign=\"top\">" . freshports_SideBar() . "</td></tr></table>\n" . freshports_ShowFooter());
+		$this->addBodyContent("\n</table><td class=\"sidebar\" valign=\"top\">" . freshports_SideBar() . "</td></tr></table>\n" . freshports_ShowFooter());
 
 		return parent::toHTML();
 	}

--- a/include/watch-lists.php
+++ b/include/watch-lists.php
@@ -122,7 +122,7 @@ function freshports_UpdatingOutput($NumRowsUpdating, $PortsUpdating, $port) {
 	if ($NumRowsUpdating > 0) {
 		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
 		$HTML .= "<TR>\n";
-		$HTML .= freshports_PageBannerText('<a id="updating">Notes from UPDATING</a>', 1);
+		$HTML .= freshports_PageBannerText('<a id="updating">Notes from UPDATING</a>');
 		$HTML .= "<tr><td><dl>\n";
 		$HTML .= "<dt>These upgrade notes are taken from <a href=\"/UPDATING\">/usr/ports/UPDATING</a></dt>";
 		$HTML .= "<dd><ul>\n";

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -83,7 +83,6 @@ function freshports_CategoryDisplay($db, $category, $PageNumber = 1, $PageSize =
 
 #		var_dump($category);
 #
-	GLOBAL $TableWidth;
 	GLOBAL $User;
 
 	$Debug = 0;

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -293,7 +293,7 @@ if ($ShowAds && $BannerAd) {
 
 	echo $HTML;
 ?>	
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -293,7 +293,7 @@ if ($ShowAds && $BannerAd) {
 
 	echo $HTML;
 ?>	
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -175,7 +175,7 @@ function freshports_CategoryDisplay($db, $category, $PageNumber = 1, $PageSize =
 
 		$HTML = freshports_MainTable();
 
-		$HTML .= '<tr><td valign="top" width="100%">';
+		$HTML .= '<tr><td class="content">';
 
 		$HTML .= freshports_MainContentTable() . '
 

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -200,7 +200,7 @@ function freshports_NonPortDescription($db, $element_record) {
 ?>
 
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -200,7 +200,7 @@ function freshports_NonPortDescription($db, $element_record) {
 ?>
 
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -33,7 +33,7 @@ function freshports_NonPortDescription($db, $element_record) {
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 <TR>

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -13,7 +13,6 @@
 	require_once('Pager/Pager.php');
 	
 function freshports_NonPortDescription($db, $element_record) {
-	GLOBAL $TableWidth;
 	GLOBAL $FreshPortsTitle;
 
 	$Debug = 0;

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -40,7 +40,7 @@ function DisplayPortCommits($port, $PageNumber) {
 	if ($NumRowsFrom + $NumRowsTo > 0) {
 		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
 		$HTML .= "<TR>\n";
-		$HTML .= freshports_PageBannerText("Port Moves", 1);
+		$HTML .= freshports_PageBannerText("Port Moves");
 		$HTML .= "<tr><td>\n";
 		$HTML .= "<ul>\n";
 	}

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -483,7 +483,7 @@ document.body.appendChild(sheet);
 ?>
 
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?php
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -483,7 +483,7 @@ document.body.appendChild(sheet);
 ?>
 
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?php
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -91,7 +91,6 @@ function _freshPorts_GetPortDisplay() {
 }
 
 function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
-	GLOBAL $TableWidth;
 	GLOBAL $FreshPortsTitle;
 	GLOBAL $User;
 

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -468,7 +468,7 @@ document.body.appendChild(sheet);
 
 <?php echo freshports_MainTable(); ?>
 
-<tr><TD VALIGN="top" width="100%">
+<tr><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 
@@ -476,7 +476,7 @@ document.body.appendChild(sheet);
 <?php echo freshports_PageBannerText("Port details" . ($branch != BRANCH_HEAD ? ' on branch ' . htmlspecialchars($branch) : '')); ?>
 </TR>
 
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 
 <?php
 	echo $HTMLPortPart2 . $HTMLPortPackages . $HTMLPortPart3;

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -47,7 +47,7 @@ Perhaps a <A HREF="/categories.php">list of categories</A> or <A HREF="/search.p
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -21,11 +21,11 @@
 <TD WIDTH="100%" VALIGN="top">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <TD class="accent" HEIGHT="29"><BIG>
+    <td class="accent"><BIG>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>
-</BIG></TD>
+</BIG></td>
 </TR>
 
 <TR>

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -29,7 +29,7 @@
 </TR>
 
 <TR>
-<TD WIDTH="100%" VALIGN="top">
+<td class="content">
 <P>
 Sorry, but I don't know anything about that.
 </P>
@@ -42,7 +42,7 @@ Sorry, but I don't know anything about that.
 Perhaps a <A HREF="/categories.php">list of categories</A> or <A HREF="/search.php">the search page</A> might be helpful.
 </P>
 
-</TD>
+</td>
 </TR>
 </TABLE>
 </TD>

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -47,7 +47,7 @@ Perhaps a <A HREF="/categories.php">list of categories</A> or <A HREF="/search.p
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -21,11 +21,11 @@
 <TD WIDTH="100%" VALIGN="top">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <TD class="accent" HEIGHT="29"><FONT COLOR="#FFFFFF"><BIG><BIG>
+    <TD class="accent" HEIGHT="29"><BIG>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>
-</BIG></BIG></FONT></TD>
+</BIG></TD>
 </TR>
 
 <TR>

--- a/www/--/forums-gone.php
+++ b/www/--/forums-gone.php
@@ -21,7 +21,7 @@
 	echo freshports_MainTable();
 ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
   <TR>

--- a/www/--/forums-gone.php
+++ b/www/--/forums-gone.php
@@ -48,7 +48,7 @@
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/--/forums-gone.php
+++ b/www/--/forums-gone.php
@@ -48,7 +48,7 @@
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/about.php
+++ b/www/about.php
@@ -114,7 +114,7 @@ About the Authors</A> for details of who else helped.</P>
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?php
 	echo freshports_SideBar();
 	?>

--- a/www/about.php
+++ b/www/about.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 

--- a/www/about.php
+++ b/www/about.php
@@ -127,7 +127,7 @@ About the Authors</A> for details of who else helped.</P>
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/about.php
+++ b/www/about.php
@@ -114,7 +114,7 @@ About the Authors</A> for details of who else helped.</P>
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?php
 	echo freshports_SideBar();
 	?>

--- a/www/authors.php
+++ b/www/authors.php
@@ -116,7 +116,7 @@ name just so it stays a secret.</LI>
 </TABLE>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/authors.php
+++ b/www/authors.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 

--- a/www/authors.php
+++ b/www/authors.php
@@ -116,7 +116,7 @@ name just so it stays a secret.</LI>
 </TABLE>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -82,7 +82,7 @@ if (IsSet($_REQUEST['edit'])) {
                'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <?php
 

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -106,7 +106,7 @@ echo '
 
 echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
-<TD class="accent" COLSPAN="1">' . $Title . '</TD>
+<TD class="accent" COLSPAN="1"><big>' . $Title . '</big></TD>
 </TR>
 <TR>
 <TD>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -140,7 +140,7 @@ $HTML .= '</tr>'  . "\n";
 
 $HTML .= '<tr>'  . "\n";
 
-$HTML .= '<td><b>Plain text Version</b>'  . "\n";
+$HTML .= '<td colspan="3"><b>Plain text Version</b>'  . "\n";
 $HTML .= '<TEXTAREA NAME="announcement_plain" ROWS="10" COLS="60">'          . "\n";
 $HTML .= htmlspecialchars($Announcement->TextPlainGet());
 $HTML .= '</TEXTAREA>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -104,9 +104,9 @@ echo '
 <br>';
 }
 
-echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
-<TD class="accent" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>' . $Title . '</BIG></BIG></FONT></TD>
+<TD class="accent" COLSPAN="1">' . $Title . '</TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -108,7 +108,7 @@ echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
 <TD class="accent" COLSPAN="1">' . $Title . '</TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo 'Current annoucements<blockquote>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -106,7 +106,7 @@ echo '
 
 echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
 <TR>
-<TD class="accent" COLSPAN="1"><big>' . $Title . '</big></TD>
+<td class="accent"><big>' . $Title . '</big></td>
 </TR>
 <TR>
 <TD>';

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -83,7 +83,7 @@ if (IsSet($_REQUEST['edit'])) {
 ?>
 
 <TABLE class="fullwidth borderless" ALIGN="center">
-<TR><TD VALIGN="top" width="100%">
+<TR><td class="content">
 <?php
 
 

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -224,7 +224,7 @@ if ($NumRows > 0) {
 
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -224,7 +224,7 @@ if ($NumRows > 0) {
 
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -179,8 +179,8 @@ function MyDisplayAnnouncements($Announcement) {
 		$Announcement->FetchNth($i);
 		$HTML .= '<tr>' . "\n";
 		$HTML .= '<td>' . $Announcement->TextGet()      . '</td>';
-		$HTML .= '<td>' . ($Announcement->StartDateGet() != '' ? $Announcement->StartDateGet() : '&nbsp') . '</td>';
-		$HTML .= '<td>' . ($Announcement->EndDateGet()   != '' ? $Announcement->EndDateGet()   : '&nbsp') . '</td>';
+		$HTML .= '<td>' . ($Announcement->StartDateGet() != '' ? $Announcement->StartDateGet() : '&nbsp;') . '</td>';
+		$HTML .= '<td>' . ($Announcement->EndDateGet()   != '' ? $Announcement->EndDateGet()   : '&nbsp;') . '</td>';
 		$HTML .= '<td><a href="' . $_SERVER['PHP_SELF']  . '?edit='   . $Announcement->IDGet() . '">Edit</a></td>';
 		$HTML .= '<td><a href="' . $_SERVER['PHP_SELF']  . '?delete=' . $Announcement->IDGet() . '">Delete</a></td>';
       $HTML .= '</tr>' . "\n";

--- a/www/backend/index.php
+++ b/www/backend/index.php
@@ -22,7 +22,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 
@@ -30,7 +30,7 @@
 <tr>
 	<?php echo freshports_PageBannerText("FreshPorts News Feeds"); ?>
 </tr>
-<TR><TD valign="top" width="100%">
+<TR><td class="content">
 <h1>FreshPorts News Feeds</h1>
 
 <p>

--- a/www/backend/index.php
+++ b/www/backend/index.php
@@ -63,7 +63,7 @@ $Hostname = $_SERVER['HTTP_HOST'];
 The above feeds are created using <a href="https://github.com/flack/UniversalFeedCreator">UniversalFeedCreator</a>.
 </table>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/backend/index.php
+++ b/www/backend/index.php
@@ -63,7 +63,7 @@ $Hostname = $_SERVER['HTTP_HOST'];
 The above feeds are created using <a href="https://github.com/flack/UniversalFeedCreator">UniversalFeedCreator</a>.
 </table>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -20,7 +20,7 @@
 
 ?>
 
-<TABLE width="<? echo $TableWidth ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 
 <TR><TD valign="top" width="100%">
 <TABLE class="fullwidth borderless">

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -22,7 +22,7 @@
 
 <TABLE class="fullwidth borderless" ALIGN="center">
 
-<TR><TD valign="top" width="100%">
+<TR><td class="content">
 <TABLE class="fullwidth borderless">
 <TR>
 	<? echo freshports_PageBannerText($Title); ?>

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -128,7 +128,7 @@ if ($result) {
 
 <sup>*</sup>The users column indicates the number of logged-in users who last accessed the system on that day.
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/backend/status.php
+++ b/www/backend/status.php
@@ -128,7 +128,7 @@ if ($result) {
 
 <sup>*</sup>The users column indicates the number of logged-in users who last accessed the system on that day.
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/bouncing.php
+++ b/www/bouncing.php
@@ -92,7 +92,7 @@ the button below.</p>
 </table>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/bouncing.php
+++ b/www/bouncing.php
@@ -92,7 +92,7 @@ the button below.</p>
 </table>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/bouncing.php
+++ b/www/bouncing.php
@@ -47,7 +47,7 @@ if ($submit) {
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -218,7 +218,7 @@ freshports_echo_HTML_flush();
 echo $HTML;                                                   
 ?>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/categories.php
+++ b/www/categories.php
@@ -55,7 +55,7 @@
 	echo freshports_MainTable();
 ?>
 
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 
 <?php echo freshports_MainContentTable(BORDER, $ColSpan); ?>
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -55,9 +55,9 @@
 	echo freshports_MainTable();
 ?>
 
-<tr><td colspan="<?php echo $ColSpan; ?>" valign="top" width="100%">
+<tr><td valign="top" width="100%">
 
-<?php echo freshports_MainContentTable(BORDER, 6); ?>
+<?php echo freshports_MainContentTable(BORDER, $ColSpan); ?>
 
   <tr>
 	<? echo freshports_PageBannerText("$FreshPortsTitle - list of categories", $ColSpan); ?>
@@ -152,7 +152,7 @@ if ($sort == "last_update") {
 $HTML .= freshports_echo_HTML('</tr>');
 
 if (!$result) {
-   print pg_errormessage() . "<br>\n";
+   echo "<tr><td colspan=\"$ColSpan\"" . pg_errormessage() . "</td></tr></table>\n";
    exit;
 } else {
 	$NumTopics	   = 0;
@@ -198,7 +198,7 @@ if (!$result) {
 		}
       }
     } else {
-        $HTML .= "<tr><td colspan=5>No categories statistics found.  I bet the refresh script is not running.</td></tr>";
+        $HTML .= "<tr><td colspan=\"$ColSpan\">No categories statistics found.  I bet the refresh script is not running.</td></tr>";
     }
 }
 
@@ -209,7 +209,7 @@ if ($AllowedToEdit) {
 
 $HTML .= freshports_echo_HTML("<td ALIGN=\"right\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>");
 
-$HTML .= freshports_echo_HTML("<tr><td colspan=\"5\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>");
+$HTML .= freshports_echo_HTML("<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>");
 
 $HTML .= freshports_echo_HTML('</table>');
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -218,7 +218,7 @@ freshports_echo_HTML_flush();
 echo $HTML;                                                   
 ?>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -142,7 +142,7 @@ Well, I'm sorry to advise you that this page is intentionally left blank.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -142,7 +142,7 @@ Well, I'm sorry to advise you that this page is intentionally left blank.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -41,7 +41,7 @@
 
 ?>
 <TABLE class="fullwidth borderless" ALIGN="center">
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 <TABLE class="fullwidth borderless">
 
 <TR>
@@ -140,7 +140,7 @@ Well, I'm sorry to advise you that this page is intentionally left blank.
 ?>
 </TD></TR>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
   <?

--- a/www/category-maintenance.php
+++ b/www/category-maintenance.php
@@ -40,7 +40,7 @@
 					'FreeBSD, index, applications, ports');
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" WIDTH="100%">
 <TABLE class="fullwidth borderless">
 

--- a/www/commit.php
+++ b/www/commit.php
@@ -155,7 +155,7 @@ if ($Debug) echo "UserID='$User->id'";
 if (file_exists("announcement.txt") && filesize("announcement.txt") > 4) {
 ?>
   <TR>
-    <TD colspan="2">
+    <TD>
        <? include ("announcement.txt"); ?>
     </TD>
   </TR>
@@ -169,7 +169,7 @@ if (file_exists("announcement.txt") && filesize("announcement.txt") > 4) {
 ?>
 
 <TR>
-	<? echo freshports_PageBannerText($Title, 3); ?>
+	<? echo freshports_PageBannerText($Title); ?>
 </TR>
 
 <?php

--- a/www/commit.php
+++ b/www/commit.php
@@ -355,7 +355,7 @@ ORDER BY port, element_pathname";
 
 ?>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/commit.php
+++ b/www/commit.php
@@ -355,7 +355,7 @@ ORDER BY port, element_pathname";
 
 ?>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 
 	<?
 	echo freshports_SideBar();

--- a/www/commit.php
+++ b/www/commit.php
@@ -147,7 +147,7 @@ if ($Debug) echo "UserID='$User->id'";
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(BORDER); ?>
 
@@ -348,7 +348,7 @@ ORDER BY port, element_pathname";
 		$HTML .=  "no connection";
 	} # if ($database )
 	} else {
-		echo '<tr><td valign="top" width="100%">nothing supplied, nothing found!</td>';
+		echo '<tr><td class="content">nothing supplied, nothing found!</td>';
 	} # if ($message_id != '' || $revision != '')
 	}  # if ($cached)
 

--- a/www/commits.php
+++ b/www/commits.php
@@ -77,9 +77,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/commits.php
+++ b/www/commits.php
@@ -113,7 +113,7 @@ if ($db) {
 <?php echo freshports_MainContentTable(); ?>
 
 <TR>
-<? echo freshports_PageBannerText($Title, 3); ?>
+<? echo freshports_PageBannerText($Title); ?>
         <? //echo ($StartAt + 1) . " - " . ($StartAt + $MaxNumberOfPortsLong) ?>
 </TR>
 <TR><TD>

--- a/www/commits.php
+++ b/www/commits.php
@@ -171,7 +171,7 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
    <? echo freshports_SideBar(); ?>
 
 <BR>

--- a/www/commits.php
+++ b/www/commits.php
@@ -171,7 +171,7 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 
 <BR>
@@ -202,7 +202,7 @@ A port is marked as new for 10 days.
 		}
 	}
 ?>
- </TD>
+ </td>
 </TR>
 </TABLE>
 

--- a/www/commits.php
+++ b/www/commits.php
@@ -108,7 +108,7 @@ if (Is_Numeric($dailysummary)) {
 
 if ($db) {
 ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 
@@ -170,7 +170,7 @@ A port is marked as new for 10 days.
 
 ?>
 </TABLE>
-</TD>
+</td>
   <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 

--- a/www/committer-opt-in.php
+++ b/www/committer-opt-in.php
@@ -177,7 +177,7 @@ if (!empty($visitor)) {
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/committer-opt-in.php
+++ b/www/committer-opt-in.php
@@ -177,7 +177,7 @@ if (!empty($visitor)) {
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/committer-opt-in.php
+++ b/www/committer-opt-in.php
@@ -76,7 +76,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 <TR>

--- a/www/confirmation.php
+++ b/www/confirmation.php
@@ -36,7 +36,7 @@
 
 
 <?php echo freshports_MainTable(); ?>
-<tr><td VALIGN=TOP width="100%">
+<tr><td class="content">
 <TABLE class="fullwidth">
 <TR>
 	<? echo freshports_PageBannerText("Account confirmation"); ?>

--- a/www/confirmation.php
+++ b/www/confirmation.php
@@ -78,7 +78,7 @@
 </table>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 
 	<?
 	echo freshports_SideBar();

--- a/www/confirmation.php
+++ b/www/confirmation.php
@@ -78,7 +78,7 @@
 </table>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/contact.php
+++ b/www/contact.php
@@ -50,7 +50,7 @@ email: dan (at) langille.org.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/contact.php
+++ b/www/contact.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 

--- a/www/contact.php
+++ b/www/contact.php
@@ -50,7 +50,7 @@ email: dan (at) langille.org.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -12,6 +12,11 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
     font-size: 12px;
 }
 
+td.content {
+  width: 100%;
+  vertical-align: top;
+}
+
 .sidebar {
   vertical-align: top;
   text-align: center;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -14,6 +14,8 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 .accent {
   background-color: #8c0707;
   background-color: var(--beastie-red);
+  color: white;
+  font-size: larger;
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -35,6 +35,7 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
   background-color: var(--beastie-red);
   color: white;
   font-size: larger;
+  height: 30px;
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -12,6 +12,11 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
     font-size: 12px;
 }
 
+.sidebar th {
+  text-align: left;
+  font-weight: bolder;
+}
+
 .accent {
   background-color: #8c0707;
   background-color: var(--beastie-red);
@@ -226,7 +231,7 @@ table.bordered {
   border-spacing: 0;
 }
 
-table.bordered > tbody > tr > td {
+table.bordered > tbody > tr > td, table.bordered > tbody > tr > th {
   border: 1px inset black;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -225,6 +225,13 @@ li.extraspace {
 .packages th { background-color:#000; color:white; }
 .packages td, .packages th { padding:8px; border:1px solid #000; }
 
+.footer .sponsors {
+  text-align: left;
+}
+
+.footer .copyright {
+  text-align: right;
+}
 
 /* for horizontal scrolling of package tables - re https://www.w3schools.com/howto/howto_css_menu_horizontal_scroll.asp#contact */
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -3,6 +3,7 @@
 }
 
 body {
+  background-color: white;
   color: black;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -12,6 +12,11 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
     font-size: 12px;
 }
 
+.sidebar {
+  vertical-align: top;
+  text-align: center;
+}
+
 .sidebar th {
   text-align: left;
   font-weight: bolder;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -22,6 +22,10 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
   font-weight: bolder;
 }
 
+.sidebar p {
+  text-align: center;
+}
+
 .accent {
   background-color: #8c0707;
   background-color: var(--beastie-red);

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -17,6 +17,10 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
   text-align: center;
 }
 
+.sidebar td, .sidebar th {
+  padding: 5px;
+}
+
 .sidebar th {
   text-align: left;
   font-weight: bolder;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -2,6 +2,10 @@
   --beastie-red: #8c0707;
 }
 
+body {
+  color: black;
+}
+
 BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 {
     font-size: 12px;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -12,6 +12,10 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
     font-size: 12px;
 }
 
+table.maincontent > tbody > tr > td {
+  padding: 8px;
+}
+
 td.content {
   width: 100%;
   vertical-align: top;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -17,6 +17,10 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
   text-align: center;
 }
 
+.sidebar > table {
+  width: 160px;
+}
+
 .sidebar td, .sidebar th {
   padding: 5px;
 }

--- a/www/customize.php
+++ b/www/customize.php
@@ -168,11 +168,11 @@ UPDATE users
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth bordeless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -200,12 +200,12 @@ if ($AccountModified) {
    echo "Your account details were successfully updated.";
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -234,7 +234,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/customize.php
+++ b/www/customize.php
@@ -161,7 +161,7 @@ UPDATE users
 ?>
 
 <TABLE class="fullwidth borderless" ALIGN="center">
-<TR><TD VALIGN="top" width="100%">
+<TR><td class="content">
 <TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
@@ -232,7 +232,7 @@ echo "</TD>
 
 </TD>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/customize.php
+++ b/www/customize.php
@@ -174,7 +174,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -207,7 +207,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo '<p>If you wish to change your password, first type your existing password, then your new password twice.  Otherwise, leave them all blank.</p><br>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -205,7 +205,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
+<TD class="accent" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR>
 <TD>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -160,7 +160,7 @@ UPDATE users
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/customize.php
+++ b/www/customize.php
@@ -205,7 +205,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" COLSPAN="1"><BIG>Customize</BIG></TD>
+<td class="accent"><BIG>Customize</BIG></td>
 </TR>
 <TR>
 <TD>';

--- a/www/customize.php
+++ b/www/customize.php
@@ -234,7 +234,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/date.php
+++ b/www/date.php
@@ -203,7 +203,7 @@ if ($NumCommits > 0) {
 
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 
 	<?
 	echo freshports_SideBar();

--- a/www/date.php
+++ b/www/date.php
@@ -127,10 +127,10 @@
 		$HTML = '';
 
 		if ($NumRows == 0) {
-			$HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
+			$HTML .= '<tr><td class="accent">' . "\n";
 			$HTML .= '   ' . FormatTime($Date, 0, "D, j M Y") . "\n";
-			$HTML .= '</TD></TR>' . "\n\n";
-			$HTML .= '<TR><TD>No commits found for that date</TD></TR>';
+			$HTML .= '</td></tr>' . "\n\n";
+			$HTML .= '<tr><td>No commits found for that date</td></tr>';
 		}
 		
 		unset($ThisCommitLogID);

--- a/www/date.php
+++ b/www/date.php
@@ -178,7 +178,7 @@ if ($NumCommits > 0) {
 
 <?php echo freshports_MainTable(); ?>
 
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 <?php
 
 echo freshports_MainContentTable();

--- a/www/date.php
+++ b/www/date.php
@@ -203,7 +203,7 @@ if ($NumCommits > 0) {
 
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/date.php
+++ b/www/date.php
@@ -128,7 +128,7 @@
 
 		if ($NumRows == 0) {
 			$HTML .= '<TR><TD class="accent" COLSPAN="3" HEIGHT="0">' . "\n";
-			$HTML .= '   <FONT COLOR="#FFFFFF"><BIG>' . FormatTime($Date, 0, "D, j M Y") . '</BIG></FONT>' . "\n";
+			$HTML .= '   ' . FormatTime($Date, 0, "D, j M Y") . "\n";
 			$HTML .= '</TD></TR>' . "\n\n";
 			$HTML .= '<TR><TD>No commits found for that date</TD></TR>';
 		}

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -169,7 +169,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -91,7 +91,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Delete Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -121,7 +121,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -119,7 +119,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" COLSPAN="1"><BIG>Customize</BIG></TD>
+<td class="accent"><BIG>Customize</BIG></td>
 </TR>
 <TR>
 <TD>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -85,11 +85,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Deleted Failed!</font></b></TD>
+<TR class="accent"><TD><b>Delete Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -114,12 +114,12 @@ echo '<p>If you need help, please email postmaster@. </p>
 <br>';
 }  // if ($errors)
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Customize</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -78,7 +78,7 @@ if (IsSet($submit)) {
 ?>
 
 <TABLE class="fullwidth borderless" ALIGN="center">
-<TR><TD VALIGN="top" width="100%">
+<TR><td class="content">
 <TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
@@ -167,7 +167,7 @@ echo "</TD>
 ?>
 </TD>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -119,7 +119,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Customize</BIG></TD>
+<TD class="accent" COLSPAN="1"><BIG>Customize</BIG></TD>
 </TR>
 <TR>
 <TD>';

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -77,7 +77,7 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -169,7 +169,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/faq.php
+++ b/www/faq.php
@@ -25,7 +25,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 

--- a/www/faq.php
+++ b/www/faq.php
@@ -878,7 +878,7 @@ now that the Master has been upgraded.
 </table>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?php
 	echo freshports_SideBar();
 	?>

--- a/www/faq.php
+++ b/www/faq.php
@@ -878,7 +878,7 @@ now that the Master has been upgraded.
 </table>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?php
 	echo freshports_SideBar();
 	?>

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -297,7 +297,7 @@ echo "</table>\n";
 <?php # main article table finish ?>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -141,6 +141,7 @@ if ($Debug) echo 'when calling freshports_WatchListDDLBForm, $wlid = \'' . $wlid
 echo freshports_WatchListDDLBForm($db, $User->id, $wlid);
 
 ?>
+</td>
 </tr></table>
 
 <?php # ddlb finish ?>
@@ -152,7 +153,7 @@ echo freshports_WatchListDDLBForm($db, $User->id, $wlid);
 </td></tr>
 
 
-<tr><td colspan="2">
+<tr><td>
 &nbsp;
 </td></tr>
 <?php
@@ -169,8 +170,6 @@ $sql = "
 
 if ($Debug) echo "<pre>$sql</pre>";
 
-
-echo '<tr><td align="center">' . "\n";
 
 $result  = pg_exec ($db, $sql);
 $numrows = pg_numrows($result);
@@ -212,7 +211,7 @@ for ($i = 0; $i < $numrows; $i++) {
 # categories list start
 
 $HTML .= "\n" . '<TABLE class="bordered" CELLPADDING="5">' . "\n";
-$HTML .= '<tr>';
+$HTML .= '<tr><td>';
 // get the list of categories to display
 $sql = "
     select categories.id          as category_id, 

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -297,7 +297,7 @@ echo "</table>\n";
 <?php # main article table finish ?>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/filter-setup.php
+++ b/www/filter-setup.php
@@ -109,14 +109,14 @@ if ($_REQUEST['wlid']) {
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 <?php # article table start ?>
   <tr>
 	<? echo freshports_PageBannerText("Watch List - categories"); ?>
   </tr>
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 
 
 <table class="fullwidth borderless">

--- a/www/filter.php
+++ b/www/filter.php
@@ -171,7 +171,7 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
    <? echo freshports_SideBar(); ?>
 
 <BR>

--- a/www/filter.php
+++ b/www/filter.php
@@ -107,7 +107,7 @@ if (Is_Numeric($dailysummary)) {
 
 if ($db) {
 ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 
@@ -170,7 +170,7 @@ A port is marked as new for 10 days.
 
 ?>
 </TABLE>
-</TD>
+</td>
   <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 

--- a/www/filter.php
+++ b/www/filter.php
@@ -171,7 +171,7 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 
 <BR>
@@ -202,7 +202,7 @@ A port is marked as new for 10 days.
 		}
 	}
 ?>
- </TD>
+ </td>
 </TR>
 </TABLE>
 

--- a/www/filter.php
+++ b/www/filter.php
@@ -112,7 +112,7 @@ if ($db) {
 <?php echo freshports_MainContentTable(); ?>
 
 <TR>
-<? echo freshports_PageBannerText("$MaxNumberOfPortsLong most recent commits", 3); ?>
+<? echo freshports_PageBannerText("$MaxNumberOfPortsLong most recent commits"); ?>
         <? //echo ($StartAt + 1) . " - " . ($StartAt + $MaxNumberOfPortsLong) ?>
 </TR>
 <TR><TD>

--- a/www/filter.php
+++ b/www/filter.php
@@ -63,9 +63,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -187,7 +187,7 @@ A port is marked as new for 10 days.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -138,7 +138,7 @@ if (IsSet($submit)) {
  <TR>
     <TD>
 <TABLE class="fullwidth borderless">
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 <?
 
 if (IsSet($error) and $error != '') {
@@ -262,7 +262,7 @@ we're only dealing with your FreshPorts login, not a financial transaction....</
 </TD>
 </TR>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -142,11 +142,11 @@ if (IsSet($submit)) {
 <?
 
 if (IsSet($error) and $error != '') {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">We have a problem!</FONT></b></TD>
+                 <TR class="accent"><TD><b>We have a problem!</b></TD>
                  </TR> 
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -169,11 +169,11 @@ if (IsSet($error) and $error != '') {
 } else {
 
    if ($LoginFailed || $eMailFailed) {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b><FONT COLOR="#ffffff" SIZE="+2">UserID not found!</FONT></b></TD>
+                 <TR class="accent"><TD><b>UserID not found!</b></TD>
                  </TR>
                  <TR BGCOLOR="#ffffff">
             <TD>
@@ -211,12 +211,12 @@ if (IsSet($error) and $error != '') {
 }
 ?>
 
-<TABLE CELLPADDING="1" class="fullwidth borderless accent"> <TR> <TD>
+<TABLE CELLPADDING="1" class="fullwidth borderless"> <TR> <TD>
 
 
-<TABLE class="fullwidth borderless accent" CELLPADDING="5">
+<TABLE class="fullwidth borderless" CELLPADDING="5">
 
-<TR class="accent" ><TD class="accent"><FONT COLOR="#ffffff" SIZE="+2">
+<TR class="accent" ><TD class="accent">
 <?
 if ($MailSent) {
    echo "Mail sent to your address";
@@ -224,7 +224,7 @@ if ($MailSent) {
    echo "Forgotten your password?";
 }
 ?>
-</FONT></TD></TR>
+</TD></TR>
 
 <TR><TD BGCOLOR="#ffffff">
 <?

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -173,7 +173,7 @@ if (IsSet($error) and $error != '') {
             <TR>
             <TD>
                <TABLE class="fullwidth borderless" CELLPADDING="1">
-                 <TR class="accent"><TD><b>UserID not found!</b></TD>
+                 <TR class="accent"><TD><b>User ID not found!</b></TD>
                  </TR>
                  <TR>
             <TD>

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -148,7 +148,7 @@ if (IsSet($error) and $error != '') {
                <TABLE class="fullwidth borderless" CELLPADDING="1">
                  <TR class="accent"><TD><b>We have a problem!</b></TD>
                  </TR> 
-                 <TR BGCOLOR="#ffffff">
+                 <TR>
             <TD>
               <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN="middle">
@@ -175,7 +175,7 @@ if (IsSet($error) and $error != '') {
                <TABLE class="fullwidth borderless" CELLPADDING="1">
                  <TR class="accent"><TD><b>UserID not found!</b></TD>
                  </TR>
-                 <TR BGCOLOR="#ffffff">
+                 <TR>
             <TD>
               <TABLE class="fullwidth borderless" CELLPADDING="3">
               <TR VALIGN=top>
@@ -226,7 +226,7 @@ if ($MailSent) {
 ?>
 </TD></TR>
 
-<TR><TD BGCOLOR="#ffffff">
+<TR><TD>
 <?
 if ($MailSent) {
 ?>

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -264,7 +264,7 @@ we're only dealing with your FreshPorts login, not a financial transaction....</
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -264,7 +264,7 @@ we're only dealing with your FreshPorts login, not a financial transaction....</
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/fp2-announcement.php
+++ b/www/fp2-announcement.php
@@ -19,7 +19,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 
@@ -114,7 +114,7 @@ The following items deal with the technical changes which have occurred.
 
 </TD></TR>
 </TABLE>
-</TD>
+</td>
   <td class="sidebar">
 
 	<?

--- a/www/fp2-announcement.php
+++ b/www/fp2-announcement.php
@@ -115,7 +115,7 @@ The following items deal with the technical changes which have occurred.
 </TD></TR>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/fp2-announcement.php
+++ b/www/fp2-announcement.php
@@ -115,7 +115,7 @@ The following items deal with the technical changes which have occurred.
 </TD></TR>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 
 	<?
 	echo freshports_SideBar();

--- a/www/fraud/fraud.php
+++ b/www/fraud/fraud.php
@@ -11,9 +11,9 @@
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><td VALIGN=TOP>
-<TABLE WIDTH="100%" ALIGN="left" border="0">
+<TABLE class="fullwidth borderless" ALIGN="left">
 <TR>
 	<? echo freshports_PageBannerText("Fraud - This is not FreshPorts.org!"); ?>
 </TR>

--- a/www/fraud/index.php
+++ b/www/fraud/index.php
@@ -15,9 +15,9 @@
 					"FreeBSD, index, applications, ports");
 
 ?>
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><td VALIGN=TOP>
-<TABLE WIDTH="100%" ALIGN="left" border="0">
+<TABLE class="fullwidth borderless" ALIGN="left">
 <TR>
 	<? echo freshports_PageBannerText("Fraud"); ?>
 </TR>
@@ -95,7 +95,7 @@ domain back to the registrar.
 </TABLE>
 
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" BORDER="0" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/graphs.php
+++ b/www/graphs.php
@@ -105,7 +105,7 @@ If you have suggestions for graphs, please raise an issue.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/graphs.php
+++ b/www/graphs.php
@@ -105,7 +105,7 @@ If you have suggestions for graphs, please raise an issue.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/graphs.php
+++ b/www/graphs.php
@@ -17,7 +17,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 
@@ -103,7 +103,7 @@ If you have suggestions for graphs, please raise an issue.
 </TD></TR>
 
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/graphs2.php
+++ b/www/graphs2.php
@@ -126,7 +126,7 @@ Thank you for your help.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/graphs2.php
+++ b/www/graphs2.php
@@ -126,7 +126,7 @@ Thank you for your help.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/graphs2.php
+++ b/www/graphs2.php
@@ -27,7 +27,7 @@
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 
@@ -124,7 +124,7 @@ Thank you for your help.
 </TD></TR>
 
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/help.php
+++ b/www/help.php
@@ -164,7 +164,7 @@ your staging area before uploading again.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/help.php
+++ b/www/help.php
@@ -164,7 +164,7 @@ your staging area before uploading again.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/help.php
+++ b/www/help.php
@@ -18,7 +18,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 <TR>
@@ -162,7 +162,7 @@ your staging area before uploading again.
 
 	
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/how-big-is-it.php
+++ b/www/how-big-is-it.php
@@ -92,7 +92,7 @@ function DBSize($db) {
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 

--- a/www/how-big-is-it.php
+++ b/www/how-big-is-it.php
@@ -465,7 +465,7 @@ echo number_format($Value) . '<br>';
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/how-big-is-it.php
+++ b/www/how-big-is-it.php
@@ -465,7 +465,7 @@ echo number_format($Value) . '<br>';
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/index.php
+++ b/www/index.php
@@ -81,9 +81,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -214,7 +214,7 @@ if ($db) {
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/index.php
+++ b/www/index.php
@@ -132,9 +132,9 @@ if ($db) {
 <TR>
 <?php
  if ( $Branch == BRANCH_HEAD) {
-   echo freshports_PageBannerText("$MaxNumberOfPortsLong most recent commits", 3);
+   echo freshports_PageBannerText("$MaxNumberOfPortsLong most recent commits");
  } else {
-   echo freshports_PageBannerText("Commits from the $Branch branch", 3);
+   echo freshports_PageBannerText("Commits from the $Branch branch");
  }
  
 ?>

--- a/www/index.php
+++ b/www/index.php
@@ -198,7 +198,7 @@ if ($db) {
 ?>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 
 <BR>
@@ -229,7 +229,7 @@ if ($db) {
 		}
 	}
 ?>
- </TD>
+ </td>
 </TR>
 </TABLE>
 

--- a/www/index.php
+++ b/www/index.php
@@ -125,7 +125,7 @@ if (Is_Numeric($dailysummary)) {
 
 if ($db) {
 ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 
@@ -197,7 +197,7 @@ if ($db) {
 
 ?>
 </TABLE>
-</TD>
+</td>
   <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 

--- a/www/index.php
+++ b/www/index.php
@@ -198,7 +198,7 @@ if ($db) {
 ?>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
    <? echo freshports_SideBar(); ?>
 
 <BR>

--- a/www/inthenews.php
+++ b/www/inthenews.php
@@ -43,7 +43,7 @@ Daily Daemon News - <a href="https://daily.daemonnews.org/view_story.php3?story_
 </TR>
 </TABLE>
 </td>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/inthenews.php
+++ b/www/inthenews.php
@@ -43,7 +43,7 @@ Daily Daemon News - <a href="https://daily.daemonnews.org/view_story.php3?story_
 </TR>
 </TABLE>
 </td>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 
 	<?
 	echo freshports_SideBar();

--- a/www/inthenews.php
+++ b/www/inthenews.php
@@ -19,7 +19,7 @@
 
 ?>
 	<?php echo freshports_MainTable(); ?>
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 <table class="fullwidth borderless">
   <tr>
 	<? echo freshports_PageBannerText("In the news"); ?>

--- a/www/legal.php
+++ b/www/legal.php
@@ -25,7 +25,7 @@
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">LEGAL NOTICE</FONT></TD>
+    <TD class="accent" height="32">LEGAL NOTICE</TD>
   </TR>
   <TR><TD>This page contains our obligatory legal notice.  I really don't like having to say
           these things, but given the nature of some people, I must.  For the rest of you,
@@ -33,7 +33,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">COPYRIGHT</FONT></TD>
+    <TD class="accent" height="32">COPYRIGHT</TD>
   </TR>
   <TR><TD>
   <p>Copyright <?php echo COPYRIGHTYEARS; ?> Dan Langille All rights reserved.&nbsp; Copyright in
@@ -49,7 +49,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">CONTENT AND LIABILITY DISCLAIMER</FONT></TD>
+    <TD class="accent" height="32">CONTENT AND LIABILITY DISCLAIMER</TD>
   </TR>
   <TR><TD>
   <p>Dan Langille shall not be responsible for any errors or omissions contained at
@@ -68,7 +68,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">FEEDBACK INFORMATION</FONT></TD>
+    <TD class="accent" height="32">FEEDBACK INFORMATION</TD>
   </TR>
   <TR><TD>
   <p>Any information provided to Dan Langille in connection with any Dan Langille
@@ -78,7 +78,7 @@
   </TD></TR>
   <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32"><FONT COLOR="#FFFFFF" SIZE="+1">TRADEMARKS</FONT></TD>
+    <TD class="accent" height="32">TRADEMARKS</TD>
   </TR>
   <TR><TD>
   <p>All Dan Langille's product names are trademarks or registered trademarks of Dan Langille

--- a/www/legal.php
+++ b/www/legal.php
@@ -88,7 +88,7 @@
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/legal.php
+++ b/www/legal.php
@@ -88,7 +88,7 @@
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/legal.php
+++ b/www/legal.php
@@ -21,7 +21,7 @@
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
   <TR>
@@ -86,7 +86,7 @@
   trademarks of their respective holders. </p>
   </TD></TR>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/login.php
+++ b/www/login.php
@@ -229,7 +229,7 @@ if ($error) {
 
 echo '<TABLE class="fullwidth bordered" CELLPADDING="1">';
 
-echo '<TR class="accent">';
+echo '<TR>';
 
 echo freshports_PageBannerText("Login");
 echo '</TR>';

--- a/www/login.php
+++ b/www/login.php
@@ -157,7 +157,7 @@ if (IsSet($_GET["resend"])) {
 
 <?php echo freshports_MainTable(); ?>
  <TR>
-    <TD VALIGN="top" WIDTH="100%">
+    <td class="content">
 <?
 if ($LoginFailed) {
 ?>
@@ -248,7 +248,7 @@ echo"
 #echo '<BR><A HREF="forgotten-password.php">Forgotten your password?</a>';
 
 ?>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/login.php
+++ b/www/login.php
@@ -169,7 +169,7 @@ if ($LoginFailed) {
 <TR>
 	<? echo freshports_PageBannerText("Login Failed!") ?>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="0">
   <TR valign=top>
@@ -204,7 +204,7 @@ if ($error) {
     <? echo freshports_PageBannerText("NOTICE"); ?>
 </TR>
 
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING=0>
   <TR valign=top>
@@ -234,7 +234,7 @@ echo '<TR class="accent">';
 echo freshports_PageBannerText("Login");
 echo '</TR>';
 
-echo '<TR><TD BGCOLOR="#ffffff">';
+echo '<TR><TD>';
 include ($_SERVER['DOCUMENT_ROOT'] . "/../include/login.php");
 
 echo "Your browser must allow cookies for this login to work.";

--- a/www/login.php
+++ b/www/login.php
@@ -250,7 +250,7 @@ echo"
 ?>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/login.php
+++ b/www/login.php
@@ -227,7 +227,7 @@ if ($error) {
 
 
 
-echo '<TABLE class="fullwidth bordered accent" CELLPADDING="1">';
+echo '<TABLE class="fullwidth bordered" CELLPADDING="1">';
 
 echo '<TR class="accent">';
 

--- a/www/login.php
+++ b/www/login.php
@@ -250,7 +250,7 @@ echo"
 ?>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/my-flagged-commits.php
+++ b/www/my-flagged-commits.php
@@ -105,7 +105,7 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
    <? echo freshports_SideBar(); ?>
 
 <BR>

--- a/www/my-flagged-commits.php
+++ b/www/my-flagged-commits.php
@@ -76,7 +76,7 @@ if ($db) {
 <?php echo freshports_MainContentTable(); ?>
 
 <TR>
-<? echo freshports_PageBannerText("My flagged commits", 3); ?>
+<? echo freshports_PageBannerText("My flagged commits"); ?>
         <? //echo ($StartAt + 1) . " - " . ($StartAt + $MaxNumberOfPortsLong) ?>
 </TR>
 <TR><TD>

--- a/www/my-flagged-commits.php
+++ b/www/my-flagged-commits.php
@@ -71,7 +71,7 @@ $dailysummary = 7;
 
 if ($db) {
 ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 
@@ -104,7 +104,7 @@ A port is marked as new for 10 days.
 
 ?>
 </TABLE>
-</TD>
+</td>
   <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 

--- a/www/my-flagged-commits.php
+++ b/www/my-flagged-commits.php
@@ -105,12 +105,12 @@ A port is marked as new for 10 days.
 ?>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 
 <BR>
 
- </TD>
+ </td>
 </TR>
 </TABLE>
 

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -259,7 +259,7 @@ Your cooperation with the above will make my life easier.  Thank you.
   </TR>
 </TABLE>
 </TD>
-<td>
+<td class="sidebar">
 
 	<?
 	echo freshports_SideBar();

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -181,11 +181,11 @@ if (IsSet($submit)) {
 <TR><TD VALIGN="top" WIDTH="100%">
 <?php
 if ($errors != '') {
-echo '<TABLE CELLPADDING=1 class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING=1 class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING=1>
-<TR class="accent"><TD><B><FONT color="#ffffff" size=+0>Access Code Failed!</FONT></B></TD>
+<TR class="accent"><TD><B>Access Code Failed!</B></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -178,7 +178,7 @@ if (IsSet($submit)) {
 ?>
 
 <?php echo freshports_MainTable(); ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 <?php
 if ($errors != '') {
 echo '<TABLE CELLPADDING=1 class="fullwidth borderless">

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -265,6 +265,7 @@ Your cooperation with the above will make my life easier.  Thank you.
 	echo freshports_SideBar();
 	?>
 
+</td>
 </TR>
 </TABLE>
 

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -187,7 +187,7 @@ echo '<TABLE CELLPADDING=1 class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING=1>
 <TR class="accent"><TD><B>Access Code Failed!</B></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING=3>
   <TR VALIGN=top>

--- a/www/now-in-maintenance-mode.php
+++ b/www/now-in-maintenance-mode.php
@@ -31,7 +31,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 

--- a/www/now-in-maintenance-mode.php
+++ b/www/now-in-maintenance-mode.php
@@ -59,7 +59,7 @@ This page will reload every <?php echo MAINTENANCE_MODE_RERESH_TIME_SECONDS; ?> 
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/now-in-maintenance-mode.php
+++ b/www/now-in-maintenance-mode.php
@@ -59,7 +59,7 @@ This page will reload every <?php echo MAINTENANCE_MODE_RERESH_TIME_SECONDS; ?> 
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/other-copyrights.php
+++ b/www/other-copyrights.php
@@ -22,7 +22,7 @@
 	<?php echo freshports_MainTable(); ?>
 
   <TR>
-	<TD VALIGN="top" WIDTH="100%">
+	<td class="content">
 	<P>
 	The copyright on the daemon you see in the website logo is as follows:
 	</P>
@@ -42,7 +42,7 @@
 	or via email at mckusick&#64;mckusick.com<BR>
 
 </BLOCKQUOTE>
-	</TD>
+	</td>
 
   <td class="sidebar">
 	<?

--- a/www/other-copyrights.php
+++ b/www/other-copyrights.php
@@ -44,7 +44,7 @@
 </BLOCKQUOTE>
 	</TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/other-copyrights.php
+++ b/www/other-copyrights.php
@@ -44,7 +44,7 @@
 </BLOCKQUOTE>
 	</TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/package.php
+++ b/www/package.php
@@ -57,7 +57,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/package.php
+++ b/www/package.php
@@ -70,7 +70,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/package.php
+++ b/www/package.php
@@ -57,7 +57,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/package.php
+++ b/www/package.php
@@ -27,7 +27,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 
@@ -55,7 +55,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 </TD></TR>
 
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -109,7 +109,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>
   <TABLE class="fullwidth borderless" CELLPADDING="3">
   <TR VALIGN=top>
@@ -144,7 +144,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
 </TR>
-<TR BGCOLOR="#ffffff">
+<TR>
 <TD>';
 
 echo '<p>Please enter your new password twice.</p><br>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -142,7 +142,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
+<td class="accent"><BIG>Reset password via token</BIG></td>
 </TR>
 <TR>
 <TD>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -169,7 +169,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -142,7 +142,7 @@ echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
+<TD class="accent" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
 </TR>
 <TR>
 <TD>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -103,11 +103,11 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless" CELLPADDING="1">
-<TR class="accent"><TD><b><font color="#ffffff" size=+0>Access Code Failed!</font></b></TD>
+<TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>
@@ -137,12 +137,12 @@ if ($PasswordReset) {
 
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless accent">
+echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG>Reset password via token</BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG>Reset password via token</BIG></TD>
 </TR>
 <TR BGCOLOR="#ffffff">
 <TD>';

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -96,7 +96,7 @@ if (IsSet($submit)) {
 ?>
 
 <TABLE class="fullwidth borderless" ALIGN="center">
-<TR><TD VALIGN="top" width="100%">
+<TR><td class="content">
 <TABLE class="fullwidth borderless">
   <TR>
     <TD height="20"><?php
@@ -167,7 +167,7 @@ echo "</TD>
 
 </TD>
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -95,7 +95,7 @@ if (IsSet($submit)) {
 						'FreeBSD, index, applications, ports');
 ?>
 
-<TABLE WIDTH="<? echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD VALIGN="top" width="100%">
 <TABLE class="fullwidth borderless">
   <TR>

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -169,7 +169,7 @@ echo "</TD>
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/pkg_process.inc
+++ b/www/pkg_process.inc
@@ -48,7 +48,7 @@ function DisplayError($error) {
 			    <? echo freshports_PageBannerText("NOTICE"); ?>
 			</TR>
 
-			<TR BGCOLOR="#ffffff">
+			<TR>
 				<TD>
 					<TABLE class="fullwidth borderless" CELLPADDING="0">
 						<TR VALIGN="top">

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -486,7 +486,7 @@ if ($Debug) echo '<br>' . __LINE__ . '<br>';
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -240,7 +240,7 @@ function ChooseWatchLists($UserID, $db) {
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 <TR>

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -205,6 +205,7 @@ function DisplayStagingArea($UserID, $WatchListID, $db) {
 	UploadDisplayWatchListItemsNotInStagingArea($WatchListID, $db);
 	echo '</TD>';
 
+	echo '</TR>';
 	echo '</TABLE>';
 }
 
@@ -213,7 +214,7 @@ function ChooseWatchLists($UserID, $db) {
 	echo '<TABLE class="fullwidth bordered" ALIGN="center" CELLPADDING="5"><TR>';
 ?>
 
-	<TR><TD colspan="3"><BIG>Your staging area contains your uploaded information.  Please choose a watch list, and click on Go.
+	<TR><TD><BIG>Your staging area contains your uploaded information.  Please choose a watch list, and click on Go.
 		 <SMALL><A HREF="/help.php">help</A></SMALL></TD></TR>
 
 	<TR><TD>

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -486,7 +486,7 @@ if ($Debug) echo '<br>' . __LINE__ . '<br>';
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/port-watch.php
+++ b/www/port-watch.php
@@ -289,7 +289,7 @@ you have selected a notification frequency within your <a href="customize.php">a
 
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/port-watch.php
+++ b/www/port-watch.php
@@ -136,7 +136,7 @@ if ($submit) {
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
   <tr>

--- a/www/port-watch.php
+++ b/www/port-watch.php
@@ -289,7 +289,7 @@ you have selected a notification frequency within your <a href="customize.php">a
 
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/ports-new.php
+++ b/www/ports-new.php
@@ -71,7 +71,7 @@
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 

--- a/www/ports-new.php
+++ b/www/ports-new.php
@@ -216,7 +216,7 @@ select NP.id,
 
 </TABLE>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/ports-new.php
+++ b/www/ports-new.php
@@ -216,7 +216,7 @@ select NP.id,
 
 </TABLE>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/privacy.php
+++ b/www/privacy.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 

--- a/www/privacy.php
+++ b/www/privacy.php
@@ -54,7 +54,7 @@ We use third-party advertising companies to serve ads when you visit our Web sit
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/privacy.php
+++ b/www/privacy.php
@@ -54,7 +54,7 @@ We use third-party advertising companies to serve ads when you visit our Web sit
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -21,7 +21,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 
@@ -46,7 +46,7 @@ to this new version.
 </TD></TR>
 
 <TR>
-<td align="left" valign="top" width="100%"></td>
+<td class="content"></td>
 </tr>
 
 	<?php 

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -203,7 +203,7 @@ needed.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -211,7 +211,7 @@ needed.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -203,7 +203,7 @@ needed.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -202,7 +202,7 @@ the following fields.
 
 </TABLE>
 
-<TABLE WIDTH="<?php echo $TableWidth; ?>" class="borderless" ALIGN="center">
+<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -194,7 +194,7 @@ the following fields.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -21,7 +21,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 
@@ -53,7 +53,7 @@ and ideas which lead to the changes I've made.
 </TD></TR>
 
 <TR>
-<td align="left" valign="top" width="100%"></td>
+<td class="content"></td>
 </tr>
 
 	<?php 
@@ -192,7 +192,7 @@ the following fields.
 </TD></TR>
 
 </TABLE>
-</TD>
+</td>
 
   <td class="sidebar">
 	<?

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -194,7 +194,7 @@ the following fields.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -146,7 +146,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><FONT COLOR="#FFFFFF"><BIG><BIG><? echo $ArticleTitle; ?></BIG></BIG></FONT></TD>
+<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG><? echo $ArticleTitle; ?></BIG></TD>
 </TR>
 <TR>
 <TD>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -146,7 +146,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" HEIGHT="29" COLSPAN="1"><BIG><? echo $ArticleTitle; ?></BIG></TD>
+<TD class="accent" COLSPAN="1"><BIG><? echo $ArticleTitle; ?></BIG></TD>
 </TR>
 <TR>
 <TD>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -143,7 +143,7 @@
 
   <TR>
 
-<TD WIDTH="100%" VALIGN="top">
+<TD class="content">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
 <td class="accent"><BIG><? echo $ArticleTitle; ?></BIG></td>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -146,7 +146,7 @@
 <TD WIDTH="100%" VALIGN="top">
 <TABLE class="fullwidth borderless" CELLPADDING="1">
 <TR>
-<TD class="accent" COLSPAN="1"><BIG><? echo $ArticleTitle; ?></BIG></TD>
+<td class="accent"><BIG><? echo $ArticleTitle; ?></BIG></td>
 </TR>
 <TR>
 <TD>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -245,7 +245,7 @@ the directions found on the <a href="https://lists.freshports.org/mailman/listin
 
 	</TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -245,7 +245,7 @@ the directions found on the <a href="https://lists.freshports.org/mailman/listin
 
 	</TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -198,7 +198,7 @@ since 10 October 2006.
 ?>
 </TABLE>
 </TD>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
    <? echo freshports_SideBar(); ?>
 
 <BR>
@@ -229,7 +229,7 @@ since 10 October 2006.
 		}
 	}
 ?>
- </TD>
+ </td>
 </TR>
 </TABLE>
 

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -89,7 +89,7 @@ if (Is_Numeric($dailysummary)) {
 
 if ($db) {
 ?>
-<TR><TD VALIGN="top" WIDTH="100%">
+<TR><td class="content">
 
 <?php echo freshports_MainContentTable(); ?>
 

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -198,7 +198,7 @@ since 10 October 2006.
 ?>
 </TABLE>
 </TD>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
    <? echo freshports_SideBar(); ?>
 
 <BR>

--- a/www/sanity_test_failures.php
+++ b/www/sanity_test_failures.php
@@ -44,9 +44,9 @@ function freshports_SummaryForDay($MinusN) {
    if (file_exists($File)) {
       echo '<br><TABLE WIDTH="152" class="bordered" CELLPADDING="5">';
       echo '  <TR>';
-      echo '<TD class="accent" height="30"><font color="#FFFFFF" SIZE="+1">';
+      echo '<TD class="accent" height="30">';
       echo date("l j M", $Now - 60*60*24*$MinusN);
-      echo '</font></TD>';
+      echo '</TD>';
       echo '       </TR>';
       echo '        <TR>';
       echo '         <TD>';
@@ -214,7 +214,7 @@ since 10 October 2006.
 			echo '
 <TABLE WIDTH="155" class="bordered" CELLPADDING="5">
 	<TR>
-		<TD class="accent" height="30"><FONT COLOR="#FFFFFF"><BIG><B>Previous days</B></BIG></FONT></TD>
+		<TD class="accent" height="30"><B>Previous days</B></TD>
 	</TR>
 	<TR><TD>
 ';

--- a/www/search.php
+++ b/www/search.php
@@ -935,6 +935,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 </td>
 <td valign="middle">
 	<INPUT TYPE=checkbox <? if ($casesensitivity == "casesensitive")   echo 'CHECKED'; ?> VALUE=casesensitive   NAME=casesensitivity> Case sensitive search
+</td>
 <td valign="middle">
 	Sort by: <SELECT name="orderby">
 		<OPTION VALUE="<?php echo ORDERBYPORT;       ?>" <?if ($orderby == ORDERBYPORT       ) echo 'SELECTED' ?>>Port
@@ -989,7 +990,6 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
   </td>
 </tr>
 
-</td>
 </table>
 </form>
 

--- a/www/search.php
+++ b/www/search.php
@@ -1137,7 +1137,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/search.php
+++ b/www/search.php
@@ -1137,7 +1137,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/search.php
+++ b/www/search.php
@@ -299,7 +299,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 
 <?php echo freshports_MainTable(); ?>
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 <?php echo freshports_MainContentTable(); ?>
   <tr>
 	<? echo freshports_PageBannerText("Search FreshPorts using Google"); ?>

--- a/www/security-policy.php
+++ b/www/security-policy.php
@@ -42,7 +42,7 @@ acknowledge the work you do and the findings you present.
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/security-policy.php
+++ b/www/security-policy.php
@@ -42,7 +42,7 @@ acknowledge the work you do and the findings you present.
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/security-policy.php
+++ b/www/security-policy.php
@@ -18,7 +18,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 

--- a/www/security-policy.php
+++ b/www/security-policy.php
@@ -29,7 +29,7 @@
 <TR><TD>
 
 <P>
-I appreciate the contributions of the security reserachers who have helped out on this
+I appreciate the contributions of the security researchers who have helped out on this
 website. Please be aware that this is not a for-profit website. It is a hobby. It is something I
 do in my spare time. It is run as a service to the open source community.
 

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -188,7 +188,7 @@ echo "</table>\n";
 <?php # main article table finish ?>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -188,7 +188,7 @@ echo "</table>\n";
 <?php # main article table finish ?>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -57,14 +57,14 @@ if ($_REQUEST['wlid']) {
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
 <?php # article table start ?>
   <tr>
 	<? echo freshports_PageBannerText("Watch List - categories"); ?>
   </tr>
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 
 
 <table class="fullwidth borderless">

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -242,7 +242,7 @@ $ErrorMessage .= CheckForNoDefaultAndAddToDefault($db, $User);
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 <TR>

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -369,7 +369,7 @@ When clicking on Add/Remove for a port,<br> the action should affect
 </p>
 </td></tr></table>
 </td>
-<td valign="top">
+<td class="sidebar" valign="top">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -369,7 +369,7 @@ When clicking on Add/Remove for a port,<br> the action should affect
 </p>
 </td></tr></table>
 </td>
-<td class="sidebar" valign="top">
+<td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/watch-list.php
+++ b/www/watch-list.php
@@ -156,7 +156,7 @@ NOTES
 </TD>
 </tr>
 </table>
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/watch-list.php
+++ b/www/watch-list.php
@@ -156,7 +156,7 @@ NOTES
 </TD>
 </tr>
 </table>
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
   <?
   echo freshports_SideBar();
   ?>

--- a/www/watch-list.php
+++ b/www/watch-list.php
@@ -72,13 +72,13 @@ function AddElementToWatchLists($db, $UserID, $ElementID, $WatchListsIDs) {
 
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
 <TR>
 	<? echo freshports_PageBannerText("Watch list maintenance"); ?>
 </TR>
-<TR><TD valign="top" width="100%">
+<TR><td class="content">
 <?php
 		if ($ErrorMessage) {
 			echo freshports_ErrorMessage("Let\'s try that again!", $ErrorMessage);

--- a/www/watch.php
+++ b/www/watch.php
@@ -70,7 +70,7 @@
 
 <?php echo freshports_MainTable(); ?>
 
-<tr><td valign="top" width="100%">
+<tr><td class="content">
 <table class="fullwidth borderless">
 <tr>
 	<? echo freshports_PageBannerText($Title); ?>

--- a/www/watch.php
+++ b/www/watch.php
@@ -401,7 +401,7 @@ if ($wlid != '') {
 </table>
 </td>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/watch.php
+++ b/www/watch.php
@@ -401,7 +401,7 @@ if ($wlid != '') {
 </table>
 </td>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/welcome.php
+++ b/www/welcome.php
@@ -20,7 +20,7 @@
 ?>
 	<?php echo freshports_MainTable(); ?>
 
-	<tr><td valign="top" width="100%">
+	<tr><td class="content">
 
 	<?php echo freshports_MainContentTable(); ?>
   <TR>

--- a/www/welcome.php
+++ b/www/welcome.php
@@ -49,7 +49,7 @@
 </TABLE>
 </TD>
 
-  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
+  <td class="sidebar">
 	<?
 	echo freshports_SideBar();
 	?>

--- a/www/welcome.php
+++ b/www/welcome.php
@@ -49,7 +49,7 @@
 </TABLE>
 </TD>
 
-  <TD VALIGN="top" WIDTH="*" ALIGN="center">
+  <TD class="sidebar" VALIGN="top" WIDTH="*" ALIGN="center">
 	<?
 	echo freshports_SideBar();
 	?>


### PR DESCRIPTION
This builds on #258 and #256.

Mostly cleaning up some table style attributes and a few cases where the columns weren't lining up correctly (differing numbers between rows).

This gets us pretty close to technically valid HTML5 for the homepage. Outstanding issues remaining:

- Still a bunch of usage of the `<big>` element
- The icons on commit listings (the current sizes are very tailored to each graphic, should I replicate that or try to make them more uniform?)
- Some tiny details on the footer (it's already off-center, but centering makes the text have wider margins than I think was intended. Should text block be up against the respective corner of the page or more towards the center?)
- There's a stray nowrap on the user info navigation table; haven't removed it yet because I need to test what impact that has once logged in
- All the other pages will still need varying degrees of work, but should already be a lot closer
- Some of the `/backend/` pages might be a bit mangled from the table cleanup, I haven't looked into how to get access to them yet in my environment to test