### PR TITLE
HTML Cleanup: Sidebar Vulnerability list & Footer

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1655,21 +1655,21 @@ function freshports_ShowFooter($PhorumBottom = 0) {
 
 
 	if ($ShowAds) {
-		$HTML .= "<div align=\"center\">\n";
+		$HTML .= "<div>\n";
 		$HTML .= Ad_728x90();
 		$HTML .= "</div>\n";
 	}
 
 	$HTML .= '
 <HR>
-<table width="98%" class="borderless">
+<table class="borderless">
 ';
 
 	if (IsSet($ShowPoweredBy)) {
 		$HTML .= '
 <tr>
 
-<td align="center">
+<td>
 
 <a href="https://www.freebsd.org/" rel="noopener noreferrer"><img src="/images/pbfbsd2.gif"
 alt="powered by FreeBSD" width="171" height="64"></a>
@@ -1685,7 +1685,7 @@ alt="powered by PostgreSQL" width="164" height="59"></a>
 
 
 </td></tr>
-<tr><td align="center">
+<tr><td>
 
 <a href="https://www.nginx.org/" rel="noopener noreferrer"><img src="/images/nginx.gif" 
 alt="powered by nginx" width="121" height="32"></a>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1851,7 +1851,7 @@ $HTML .= '<br>
 	<tr><td>
 	' . file_get_contents(HTML_DIRECTORY . '/vuln-latest.html') . "\n" . '
 	</td></tr>
-	<tr><td align="center">
+	<tr><td>
 		<p><sup>*</sup> - modified, not new</p><p><a href="/vuxml.php?all">All vulnerabilities</a></p>
 		<p>Last updated:<br>' . date('Y-m-d H:i:s', filemtime(HTML_DIRECTORY . '/vuln-latest.html')) . '</p>
 	</td></tr>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1758,7 +1758,7 @@ function freshports_SideBar() {
         </tr>
         <tr>
 
-         <td NOWRAP>';
+         <td>';
 
 	if (IsSet($_COOKIE[USER_COOKIE_NAME])) {
 		$visitor = $_COOKIE[USER_COOKIE_NAME];

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -235,6 +235,15 @@ li.extraspace {
 .packages th { background-color:#000; color:white; }
 .packages td, .packages th { padding:8px; border:1px solid #000; }
 
+.footer {
+  text-align: center;
+}
+
+.footer > tbody > tr > td > table {
+  width: 98%;
+  margin: 0 auto;
+}
+
 .footer .sponsors {
   text-align: left;
 }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -30,7 +30,8 @@ td.content {
   width: 160px;
 }
 
-.sidebar td, .sidebar th {
+.sidebar > table > tbody > tr > td,
+.sidebar > table > tbody > tr > th {
   padding: 5px;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -30,6 +30,15 @@ td.content {
   width: 160px;
 }
 
+.sidebar > table:first-child td {
+  white-space: nowrap;
+}
+
+.sidebar > table table td:nth-child(2) {
+  text-align: right;
+  white-space: nowrap;
+}
+
 .sidebar > table > tbody > tr > td,
 .sidebar > table > tbody > tr > th {
   padding: 5px;


### PR DESCRIPTION
- Fixes the additional padding mentioned in [258](https://github.com/FreshPorts/freshports/pull/258#issuecomment-832344140).
- Last cleanup for the sidebar, not counting included HTML tables
- Cleanup for the footer (also properly centered now, let me know if you want the gaps at the sides removed)
- [Attached is the diff ](https://github.com/FreshPorts/freshports/files/6425958/vuln-latest.diff.txt) for the new output for the `vuln-latest.html` file; basically drops any `align` and `nowrap` attributes, and swaps the `width` of the `table` for the `fullwidth` class 




