### PR TITLE
HTML Cleanup: commit list, footers, ads, FAQ/About pages

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -126,11 +126,13 @@ class DisplayCommit {
 			if ($mycommit->commit_log_id != $PreviousCommit->commit_log_id) {
 				if ($Debug) echo "This commit_log_id is different\n";
 				if (($NumberOfPortsInThisCommit > $MaxNumberPortsToShow) && !$this->ShowAllPorts) {
-					$this->HTML .= '<BR>' . freshports_MorePortsToShow($PreviousCommit->message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow);
+					$this->HTML .= '</ul>' . freshports_MorePortsToShow($PreviousCommit->message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow);
+				} else if ($i > 0) {
+					$this->HTML .= '</ul>';
 				}
 				$TooManyPorts = false;
 				if ($i > 0) {
-					$this->HTML .= "\n<BLOCKQUOTE>";
+					$this->HTML .= "\n<BLOCKQUOTE class=\"description\">";
 					$this->HTML .= freshports_CommitDescriptionPrint(
 			                    $PreviousCommit->commit_description,
 			                    $PreviousCommit->encoding_losses,
@@ -152,15 +154,15 @@ class DisplayCommit {
 
 				GLOBAL $freshports_mail_archive;
 
-				$this->HTML .= "<TR><TD>\n";
+				$this->HTML .= "<TR><TD class=\"commit-details\">\n";
 
-				$this->HTML .= '<SMALL>';
+				$this->HTML .= '<span class="meta">';
 				$this->HTML .= '[ ' . $mycommit->commit_time . ' ' . freshports_CommitterEmailLink($mycommit->committer);
 				if (!empty($mycommit->committer_name) && ($mycommit->committer_name != $mycommit->committer)) {
 					$this->HTML .= ' (' . $mycommit->committer_name . ')';
 				}
 				$this->HTML .= ' ]';
-				$this->HTML .= '</SMALL>';
+				$this->HTML .= '</span>';
 				$this->HTML .= '&nbsp;';
 				if ($this->IsGitCommit($mycommit->message_id)) {
 					# do nothing
@@ -196,7 +198,7 @@ class DisplayCommit {
 						$this->HTML .= '&nbsp; ' . freshports_svnweb_ChangeSet_Link($mycommit->svn_revision, $mycommit->repo_hostname);
 					}
 				}
-				$this->HTML .= "<br>\n";
+				$this->HTML .= "<ul class=\"element-list\">\n";
 
 			}
 
@@ -206,6 +208,7 @@ class DisplayCommit {
 			}
 
 			if (!$TooManyPorts) {
+				$this->HTML .= '<li>';
 				if (IsSet($mycommit->category) && $mycommit->category != '') {
 				if ($this->UserID) {
 					if ($mycommit->watch) {
@@ -215,7 +218,7 @@ class DisplayCommit {
 					}
 				}
 
-				$this->HTML .= '<BIG><B>';
+				$this->HTML .= '<span class="element-details">';
 				$this->HTML .= '<A HREF="/' . $mycommit->category . '/' . $mycommit->port . '/' . $URLBranchSuffix . '">';
 				$this->HTML .= $mycommit->port;
 				$this->HTML .= '</A>';
@@ -225,7 +228,7 @@ class DisplayCommit {
 					$this->HTML .= ' ' . $PackageVersion;
 				}
 
-				$this->HTML .= "</B></BIG>\n";
+				$this->HTML .= "</span>\n";
 
 				$this->HTML .= '<A HREF="/' . $mycommit->category . '/'  . $URLBranchSuffix . '">';
 				$this->HTML .= $mycommit->category. "</A>";
@@ -296,7 +299,7 @@ class DisplayCommit {
 			} else {
 				# This is a non-port element... 
 				$this->HTML .= $mycommit->revision . ' ';
-				$this->HTML .= '<big><B>';
+				$this->HTML .= '<span class="element-details">';
 				$PathName = preg_replace('|^/?ports/|', '', $mycommit->element_pathname);
 #				echo "'$PathName' " . "'" . $mycommit->repo_name . "'";
 				switch($mycommit->repo_name)
@@ -307,15 +310,13 @@ class DisplayCommit {
 				}
 				if ($PathName != $mycommit->element_pathname) {
 					$this->HTML .= '<a href="/' . str_replace('%2F', '/', urlencode($PathName)) . '">' . $PathName . '</a>';
-					$this->HTML .= "</B></BIG>\n";
+					$this->HTML .= "</span>\n";
 				} else {
 					$this->HTML .= '<a href="' . FRESHPORTS_FREEBSD_CVS_URL . $PathName . '#rev' . $mycommit->revision . '">' . $PathName . '</a>';
-					$this->HTML .= "</B></BIG>\n";
+					$this->HTML .= "</span>\n";
 				}
 			}
-			$this->HTML .= htmlify(_forDisplay($mycommit->short_description)) . "\n";
-
-			$this->HTML .= "<BR>\n";
+			$this->HTML .= htmlify(_forDisplay($mycommit->short_description)) . "</li>\n";
 
 			GLOBAL $freshports_CommitMsgMaxNumOfLinesToShow;			
 			if ($this->ShowEntireCommit) {
@@ -328,11 +329,13 @@ class DisplayCommit {
 
 			$PreviousCommit = $mycommit;
 		}
-		
+
 		if (($NumberOfPortsInThisCommit > $MaxNumberPortsToShow) && !$this->ShowAllPorts) {
-			$this->HTML .= '<BR>' . freshports_MorePortsToShow($PreviousCommit->message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow);
+			$this->HTML .= '</ul>' . freshports_MorePortsToShow($PreviousCommit->message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow);
+		} else {
+			$this->HTML .= '</ul>';
 		}
-		$this->HTML .= "\n<BLOCKQUOTE>";
+		$this->HTML .= "\n<BLOCKQUOTE class=\"description\">";
 		$this->HTML .= freshports_CommitDescriptionPrint(
                     $PreviousCommit->commit_description,
                     $PreviousCommit->encoding_losses,

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -553,7 +553,7 @@ class port_display {
 
 			$HTML .= port_display_WATCH_LIST_ADD_REMOVE;
 
-			$HTML .= '<big><b>';
+			$HTML .= '<span class="element-details">';
 
 			if ($this->LinkToPort) {
 				$HTML .= $this->LinkToPort();
@@ -561,7 +561,7 @@ class port_display {
 				$HTML .= $port->port;
 			}
 
-			$HTML .= "</b></big>";
+			$HTML .= "</span>";
 
 			// description
 			if ($port->short_description && ($this->ShowShortDescription || $this->ShowEverything)) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -141,7 +141,7 @@ function freshports_MainContentTable($Classes=BORDER, $ColSpan=1) {
 }
 
 function  freshports_ErrorContentTable() {
-	echo '<table class="fullwidth bordered" align="center" cellpadding="1">
+	echo '<table class="fullwidth bordered" align="center">
 ';
 }
 
@@ -1965,7 +1965,7 @@ function freshports_LinkToDate($Date, $Text = '', $BranchName = BRANCH_HEAD) {
 
 function freshports_ErrorMessage($Title, $ErrorMessage) {
 	$HTML = '
-<table class="fullwidth bordered" align="center" cellpadding="1">
+<table class="fullwidth bordered" align="center">
 <tr><td valign=TOP>
 <table class="fullwidth">
 <tr>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -321,16 +321,6 @@ function freshports_IndexFollow($URI) {
 	return $HTML;
 }
 
-function freshports_BannerSpace() {
-
-return '
-  <tr>
-    <td height="10"></td>
-  </tr>
-';
-
-}
-
 function freshports_Fallout_Icon() {
 	return '<img class="icon" src="/images/fallout-16x16.png" alt="pkg-fallout" title="pkg-fallout" width="16" height="16">';
 }

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -874,7 +874,7 @@ function freshports_HTML_Start() {
 GLOBAL $Debug;
 
 echo '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<HTML>
+<html lang="en">
 ';
 }
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1402,7 +1402,7 @@ function freshports_PortCommitPrint($commit, $category, $port, $VuXMLList) {
 	$HTML = '';
 
 	# print a single commit for a port
-	$HTML .= "<tr><td valign='top' NOWRAP>";
+	$HTML .= "<tr><td class=\"commit-details\">";
 	
 
 	$HTML .= $commit->commit_date . '<br>';
@@ -1434,7 +1434,7 @@ function freshports_PortCommitPrint($commit, $category, $port, $VuXMLList) {
 	# output the VERSION and REVISION
 	$PackageVersion = freshports_PackageVersion($commit->{'port_version'},  $commit->{'port_revision'},  $commit->{'port_epoch'});
 	if (strlen($PackageVersion) > 0) {
-		$HTML .= '&nbsp;&nbsp;<big><b>' . $PackageVersion . '</b></big>';
+		$HTML .= '&nbsp;&nbsp;<span class="element-details">' . $PackageVersion . '</span>';
 	}
 
 	if ($commit->stf_message != '') {
@@ -1589,7 +1589,7 @@ function freshports_wrap($text, $length = WRAPCOMMITSATCOLUMN) {
 }
 
 function freshports_PageBannerText($Text, $ColSpan=1) {
-	return '<td class="accent" COLSPAN="' . $ColSpan . '"><big>' . $Text . '</big></td>' . "\n";
+	return '<td class="accent" COLSPAN="' . $ColSpan . '"><span>' . $Text . '</span></td>' . "\n";
 }
 
 

--- a/include/list-of-ports.php
+++ b/include/list-of-ports.php
@@ -55,7 +55,7 @@ function freshports_ListOfPorts($result, $db, $ShowDateAdded, $ShowCategoryHeade
 						$HTML .= '<DT>';
 				}
 
-				$HTML .= '<BIG><BIG><B><a href="/' . $Category . '/">' . $Category . '</a></B></BIG></BIG>';
+				$HTML .= '<span class="element-details"><span><a href="/' . $Category . '/">' . $Category . '</a></span></span>';
 				if ($ShowCategoryHeaders) {
 					$HTML .= "</DT>\n<DD>";
 				}

--- a/include/list-of-ports.php
+++ b/include/list-of-ports.php
@@ -31,7 +31,7 @@ function freshports_ListOfPorts($result, $db, $ShowDateAdded, $ShowCategoryHeade
 	$HTML  = $PortCountText;
 	$HTML .= "<TR><TD>\n";
 
-	if ($$ShowAds) {
+	if ($ShowAds) {
 		$HTML .= "<br><center>\n" . Ad_728x90() . "\n</center>\n";
 	}
 

--- a/include/new-user.php
+++ b/include/new-user.php
@@ -9,7 +9,7 @@
 ?>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" class="borderless" cellpadding="1">
+<TABLE width="*" class="borderless">
           <TR>
             <TD VALIGN="top">
 <?php if (IsSet($Customize)) { ?>

--- a/include/password-reset-via-token.php
+++ b/include/password-reset-via-token.php
@@ -11,7 +11,7 @@
 ?>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" class="borderless" cellpadding="1">
+<TABLE width="*" class="borderless">
           <TR>
             <TD VALIGN="top">
               <INPUT TYPE="hidden" NAME="token" VALUE="<?php echo $token ?>">

--- a/www/about.php
+++ b/www/about.php
@@ -28,7 +28,7 @@
 	<?php echo freshports_PageBannerText("About this site"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 We have a few notes about this website.
 </P>
@@ -40,18 +40,13 @@ We have a few notes about this website.
 </CENTER>
 
 </TD></TR>
-
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
 <TR>
 	<?php
 	echo freshports_PageBannerText("What is a port?"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>A port is the term used to describe a collection of files which makes it extremely
 easy to install an application.  As it says in the <A HREF="https://www.freebsd.org/ports/">
@@ -66,18 +61,13 @@ we come in.</P>
 <P>For more information about the Ports tree, see <A HREF="https://www.freebsd.org/ports/">https://www.freebsd.org/ports/</A>.</P>
 
 </TD></TR>
-
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
 <TR>
 	<?php
 	echo freshports_PageBannerText("What is $FreshPortsTitle");
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P><?php echo $FreshPortsTitle; ?> lists the changes made to the ports tree. If you wish, <?php echo $FreshPortsTitle; ?> can email you 
 when your favourite port has been updated.
@@ -90,18 +80,13 @@ create ports.  We do not fix ports.  We just tell you what others have been doin
 </P>
 
 </TD></TR>
-
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
 <TR>
 	<?php
 	echo freshports_PageBannerText("OK, whose bright idea was this?");
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>This site was created by Dan Langille.  His other web feats include 
 <A HREF="https://www.freebsddiary.org/">The FreeBSD Diary</A>, <a 
 href="https://www.racingsystem.com">The Racing System</A>, 
@@ -127,7 +112,7 @@ About the Authors</A> for details of who else helped.</P>
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE class="fullwidth borderless" ALIGN="center">
+<TABLE class="fullwidth borderless">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/about.php
+++ b/www/about.php
@@ -33,11 +33,9 @@
 We have a few notes about this website.
 </P>
 
-<CENTER>
 <?php
-	if ($ShowAds) echo Ad_728x90();
+	if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 </TD></TR>
 <TR>

--- a/www/authors.php
+++ b/www/authors.php
@@ -28,11 +28,9 @@
 	<? echo freshports_PageBannerText("About the authors"); ?>
   </tr>
 <TR><TD>
-<CENTER>
 <?php
-	if ($ShowAds) echo Ad_728x90();
+	if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 <p><a href="https://www.langille.org/" rel="noopener noreferrer">Dan Langille</a> thought up the idea, found the data sources, bugged people to 
 write scripts, and did the html and database work. But he certainly didn't 

--- a/www/backend/announcements.php
+++ b/www/backend/announcements.php
@@ -104,7 +104,7 @@ echo '
 <br>';
 }
 
-echo '<TABLE CELLPADDING="1" CELLSPACING="3" class="fullwidth borderless">
+echo '<TABLE CELLSPACING="3" class="fullwidth borderless">
 <TR>
 <td class="accent"><big>' . $Title . '</big></td>
 </TR>

--- a/www/bouncing.php
+++ b/www/bouncing.php
@@ -83,11 +83,10 @@ tell FreshPorts that you want it to start using your email address again by pres
 the button below.</p>
 
 </td></tr>
-<tr><td><CENTER>
+<tr><td>
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST">
 <input TYPE="submit" VALUE="There was a problem, but it's fixed now" name="submit">
 </form>
-</CENTER>
 </td></tr>
 </table>
 </td>

--- a/www/categories.php
+++ b/www/categories.php
@@ -72,13 +72,11 @@ categories are indicated by <?php echo VIRTUAL; ?>.
 You can sort each column by clicking on the header.  e.g. click on <b>Category</b> to sort by category.
 </P>
 
-<center>
 <?php
   if ($ShowAds && $BannerAd) {
-    echo Ad_728x90();
+    echo '<CENTER>' . Ad_728x90() . '</CENTER>';
   }
 ?>
-</center>
 
 
 <?php

--- a/www/committer-opt-in.php
+++ b/www/committer-opt-in.php
@@ -83,7 +83,7 @@
 	<? echo freshports_PageBannerText("Committer opt-in"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 <?php
 	if (!preg_match(".*@FreeBSD.org", $User->email)) {
@@ -103,10 +103,6 @@ which you committed.  In the past, such problems are related to syntax errors in
 One committer referred to this service as an automated nagging mentor...
 </P>
 </TD></TR>
-
-<?
-	echo freshports_BannerSpace();
-?>
 
 <TR>
 	<?

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -61,6 +61,10 @@ td.content {
   height: 30px;
 }
 
+.accent > span {
+  font-size: larger;
+}
+
 .icon {
   max-height: 20px;
   max-width: 20px;
@@ -68,6 +72,30 @@ td.content {
   vertical-align: middle;
   margin: 1px;
 }
+
+.commit-details {
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.commit-details .meta {
+  font-size: smaller;
+}
+
+.commit-details .element-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.element-details {
+  font-size: larger;
+  font-weight: bold;
+}
+
+.element-details > span {
+  font-size: larger;
+}
+
 
 IMG#fp-logo { max-width: 100%; height: auto }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -96,6 +96,10 @@ td.content {
   font-size: larger;
 }
 
+table.maincontent td.textcontent {
+  padding-bottom: 2em;
+}
+
 
 IMG#fp-logo { max-width: 100%; height: auto }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -100,7 +100,6 @@ table.maincontent td.textcontent {
   padding-bottom: 2em;
 }
 
-
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/customize.php
+++ b/www/customize.php
@@ -168,10 +168,10 @@ UPDATE users
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD>
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR>
@@ -200,10 +200,10 @@ if ($AccountModified) {
    echo "Your account details were successfully updated.";
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR>
 <td class="accent"><BIG>Customize</BIG></td>
 </TR>

--- a/www/delete-account.php
+++ b/www/delete-account.php
@@ -85,10 +85,10 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD>
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR class="accent"><TD><b>Delete Failed!</b></TD>
 </TR>
 <TR>
@@ -114,10 +114,10 @@ echo '<p>If you need help, please email postmaster@. </p>
 <br>';
 }  // if ($errors)
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR>
 <td class="accent"><BIG>Customize</BIG></td>
 </TR>
@@ -137,7 +137,7 @@ require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
 
 ?>
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" class="borderless" cellpadding="1">
+<TABLE width="*" class="borderless">
           <TR>
             <TD VALIGN="top">
                <p>The account name is: <?php echo $User->name; ?><p>

--- a/www/faq.php
+++ b/www/faq.php
@@ -33,7 +33,7 @@
 <tr>
 	<?php echo freshports_PageBannerText("FAQ"); ?>
 </tr>
-<TR><TD>
+<TR><TD class="textcontent">
 
 <CENTER>
 <?php
@@ -45,21 +45,19 @@
 are arranged from general to specific.  The more you know, the further
 down you must read to find something you didn't already know.</P>
 </TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="what">
 <?php echo freshports_PageBannerText("What is this website about?"); ?>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	This website will help you keep up with the latest releases of your
 	favorite software.  When a new version of the software is available,
 	FreshPorts will send you an email telling you about the change.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="how">
 <?php echo freshports_PageBannerText("How do I use this?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<p>
 	Your primary FreshPorts tool is your <b>watch list</b>.  This is the
 	collection of ports which you have selected for FreshPorts to
@@ -73,12 +71,11 @@ down you must read to find something you didn't already know.</P>
 	will contain headers with the list name.  You can use that for any
 	filtering you may want to do (e.g. procmail).
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="definitions">
 <?php echo freshports_PageBannerText("Some definitions"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<p>
 	You should be familiar with the <a href="https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports.html">Ports</a>
 	section of <a href="https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/index.html">The FreeBSD Handbook</a>.
@@ -112,12 +109,11 @@ down you must read to find something you didn't already know.</P>
 	prevent binary distribution.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="watch-modify">
 <?php echo freshports_PageBannerText("How do I modify my watch list?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	There are three easy ways to modify your watch list:
 	<OL>
 	<LI>Wherever you see a port, you can click on the Add 
@@ -135,31 +131,28 @@ down you must read to find something you didn't already know.</P>
 	One-click watch list maintenance operates only upon your default
 	watch lists.  You can set one or more watch lists as being default.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="watch-empty">
 <?php echo freshports_PageBannerText("How do I empty my watch list?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	Via <a href="/watch-list-maintenance.php">Watch List Maintenance</a>.
 	Select the watch lists you wish to empty, and follow the instructions
 	provided.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="unsubscribe">
 <?php echo freshports_PageBannerText("How do I delete my account?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	You can't.  But you can unsubscribe from all of the reports
 	and you'll never hear from us again.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="port-what">
 <?php echo freshports_PageBannerText("What is a port?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	A port is a simple easy way to install an application.
 	A port is a collection of files.  These files contain the location
 	of the source file, any patches which must be applied,
@@ -168,32 +161,29 @@ down you must read to find something you didn't already know.</P>
 	details on how to use ports, please refer to the official port
 	documents in the <A HREF="https://www.FreeBSD.org/handbook/">FreeBSD
 	Handbook</A>.
-	</TD></TR
-><TR><TD>&nbsp;</TD></TR>
+	</TD></TR>
 <TR id="ports-origin">
 <?php echo freshports_PageBannerText("Where do ports come from?"); ?>
 </TR>
 
-	<TR><TD>Ports are created by other FreeBSD volunteers, just like you
+	<TR><TD class="textcontent">Ports are created by other FreeBSD volunteers, just like you
 	and just like the creators of FreshPorts.  The FreshPorts team does
 	not create ports; we just tell you about the latest changes.  The
 	FreeBSD Ports team creates, maintains, and upgrades the ports.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="port-contact">
 <?php echo freshports_PageBannerText("Who do I talk to about a port?"); ?>
 </TR>
 
-	<TR><TD>The official mailing list is freebsd-ports&#64;freebsd.org.
+	<TR><TD class="textcontent">The official mailing list is freebsd-ports&#64;freebsd.org.
 		More information all FreeBSD mailing lists can be obtained
 		from <A HREF="https://www.FreeBSD.org/handbook/eresources.html#ERESOURCES-MAIL">FreeBSD Mailing Lists</A>.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="port-get">
 <?php echo freshports_PageBannerText("How do I get these ports?"); ?>
 </TR>
 
-	<TR><TD>For full information on how to obtain the ports which appear on
+	<TR><TD class="textcontent">For full information on how to obtain the ports which appear on
 	this website, please see <A HREF="https://www.FreeBSD.org/ports/">FreeBSD Ports</A>.
 	The easiest way to get a port is via cvsup.  An abbreviated example is
 
@@ -201,12 +191,11 @@ down you must read to find something you didn't already know.</P>
 	<CODE CLASS="code">cvsup -h cvsup.your.fav.server /usr/share/examples/cvsup/ports-supfile</CODE>
 	</BLOCKQUOTE>
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="fp-site-update">
 <?php echo freshports_PageBannerText("How is the website updated?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	The source code for the entire FreeBSD operating system and the Ports tree
 	are stored in the official <A HREF="<?echo FRESHPORTS_FREEBSD_CVS_URL; ?>">FreeBSD 
 	repository</A>.  Each time a change is committed to this CVS (at one time, this was a link to cvshome.org, which is no longer related to a repo)
@@ -216,20 +205,18 @@ down you must read to find something you didn't already know.</P>
 	it than first meets the eye.  The website is updated as soon as the message
 	arrives.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="rev-number-unknown">
 <?php echo freshports_PageBannerText("What does unknown mean for a revision number?"); ?>
 </TR>
 
-	<TR><TD>It means the data has been converted from an earlier
+	<TR><TD class="textcontent">It means the data has been converted from an earlier
 		version of the FreshPorts database that did not record this information.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="fp-site-link">
 <?php echo freshports_PageBannerText("Can I link to your site?"); ?>
 </TR>
 
-	<TR><TD>Yes, thank you, you can.  No need to ask us.  Just go ahead and do it.
+	<TR><TD class="textcontent">Yes, thank you, you can.  No need to ask us.  Just go ahead and do it.
 		We prefer the name FreshPorts (one word, mixed case). The following 
 		HTML is a good place to start:
 
@@ -252,12 +239,11 @@ down you must read to find something you didn't already know.</P>
 
 		<P>Please save this graphic on your website.</P>
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="symbols">
 <?php echo freshports_PageBannerText("What do these symbols mean?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	There are a few symbols you will see in this website.
 
 	<P id="fallout"><?php echo freshports_Fallout_Icon(); ?>
@@ -419,12 +405,11 @@ make: fatal errors encountered -- cannot continue
 		Ascending / Descending: These icons appear on particular tables and allow changing the order rows are sorted by.</P>
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="bookmarks-old">
 <?php echo freshports_PageBannerText("Why don't my old bookmarks work?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<P>
 	Many things changed between FP1 and FP2. The most major change
 	was in the underlying database schema.  Not only did we move
@@ -441,22 +426,20 @@ make: fatal errors encountered -- cannot continue
 	and permanent.  They are of the form &lt;category&gt;/&lt;port&gt;.
 	</P>
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="feeds">
 <?php echo freshports_PageBannerText("Do you have any news feeds?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<P>
 	Yes.  Read <a href="/newsfeeds.php">all about it</a>!
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="fp-site-mainpage">
 <?php echo freshports_PageBannerText("Can the main page load any faster?"); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<P>
 <a href="https://<?php echo $ServerName ?>/">https://<?php echo $ServerName ?>/</a> is the main page of 
 this website.  It contains a lot of information.  You can trim this information by using parameters.
@@ -503,12 +486,11 @@ Here are a few examples:
 <b>NOTE:</b> Effective 13 November 2003, these parameters are no longer available.
 </P>
 </TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="commits-day">
 <?php echo freshports_PageBannerText("How can I view the commits for a particular day?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 	Yes, you can.  <a href="https://<?php echo $ServerName ?>/date.php">https://<?php echo $ServerName ?>/date.php</a>
 	displays all the commits for today (relative to the current server time).  
@@ -522,12 +504,12 @@ Here are a few examples:
 	The date should be of the format YYYY/MM/DD but I'm sure different formats
 	will work.  If the code has trouble figuring out what date you mean, it will guess and let you know it adjusted the date.
 
-	</TD></TR><TR><TD>&nbsp;</TD></TR>
+	</TD></TR>
 <TR id="watch-issue-add">
 <?php echo freshports_PageBannerText("Why can't I add a port to my watch list?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 	You have clicked on the <?php echo freshports_Watch_Icon_Add(); ?> icon and 
 	it doesn't change to a <?php echo freshports_Watch_Icon(); ?>.  Yes, I've
@@ -545,21 +527,19 @@ Here are a few examples:
 	<a href="/watch-list-maintenance.php">watch list settings</a>.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="watch-issue-appearance">
 <?php echo freshports_PageBannerText("Why doesn't this port appear on my watch list?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
    Please refer to the above question.
    </TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="portmoves">
 <?php echo freshports_PageBannerText("What are Port Moves?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 	Some ports (for example <a href="/net/">net</a>/<a href="/net/gift/">gift</a>) will have a section titled "Port Moves".
 	FreshPorts obtains information about ports from the commits to the 
@@ -577,12 +557,11 @@ Here are a few examples:
 
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="updating">
 <?php echo freshports_PageBannerText("What is /usr/ports/UPDATING?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 <code class="code">/usr/ports/UPDATING</code> is similar to
 <code class="code">/usr/src/UPDATING</code>, but for ports,
@@ -595,12 +574,11 @@ The <a href="/net/openldap22-client/">net/openldap22-client</a> port is a good
 example of what to expect.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="master-slave">
 <?php echo freshports_PageBannerText("What are Master/Slave ports?"); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 	Some ports are so similar to another port that it makes sense to maintain just one port
 	and specify the differences in the other port.  This is slightly similar to the way 
@@ -650,12 +628,11 @@ example of what to expect.
 	is comitted to the tree.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="toadd">
 <?php echo freshports_PageBannerText('What is this "to add the package" stuff?'); ?>
 </TR>
 
-	<TR><TD>
+	<TR><TD class="textcontent">
 	<P>
 	Included within the port description is the instruction for adding the package.
 	This information can be important when the package name does not match the
@@ -680,12 +657,11 @@ pkg install XFree86-clients
 	cluster.  Therefore, there is no package for <code>pkg install</code> to use.
 	
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="fp-search-get">
 <?php echo freshports_PageBannerText('Why does the search page use GET and not POST?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 If you visit the <a href="/search.php">search</a> page, and you run a search,
 you'll find that the URL becomes very long.  For example, 
@@ -701,12 +677,11 @@ It also makes it easier to <a href="https://validator.w3.org/">validate the HTML
 if you can provide a URL that exercises all the options that require testing.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="searchfields">
 <?php echo freshports_PageBannerText('What are all those fields I can search on?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 	For those familiar with the FreeBSD ports structure, the following fields indicate their origin:
 
@@ -740,12 +715,11 @@ $
 <sup>1</sup> This value is obtained from a file in the port directory.  For
 example <code class="code">/usr/ports/sysutils/bacula/pkg-descr</code>.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="people-watch">
 <?php echo freshports_PageBannerText('Where did this "People watching this port, also watch" feature come from?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 Like many FreshPorts features, this idea came from someone else.  Florent 
 Thoumie mentioned something about extending the ports system to include 
@@ -766,12 +740,11 @@ This information is obtained by:
 <p>
 All of this takes about 55ms.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="master-updated">
 <?php echo freshports_PageBannerText('What do you mean, the master port has been updated?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 For some slave ports, you may see a message like this, just above the <b>Commit History</b>:
 
@@ -791,12 +764,11 @@ that the slave port was still vulnerable.
 <p>
 The above notice serves as a reminder that the slave port may no longer be vulnerable.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="determine-master">
 <?php echo freshports_PageBannerText('How does FreshPorts determine the master sites?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 Each port displays the master sites from which its distfiles can be downloaded.  This
 information is obtained from "make master-sites-all".  However, this is not the only
@@ -808,12 +780,11 @@ In short, FreshPorts displays the list of master sites that should contain all
 the distfiles.  That is why we use that value, and not one of the other options.
 
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="mailto-clear">
 <?php echo freshports_PageBannerText('Why don\'t you obscure email addresses?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
 FreshPorts used to obscure email addresses, but we don't any more.  We realised that
 every email address on FreshPorts is already somewhere else first. For example:
@@ -834,13 +805,12 @@ In short, it doesn't make sense to obscure that which is freely available elsewh
 Similarly, we do not entertain requests to remove information from our website. We only report upon what exists elsewhere.
 	</TD></TR>
 
-<TR><TD>&nbsp;</TD></TR>
 
 <TR id="portversion-differ">
 <?php echo freshports_PageBannerText('Why does the PORTVERSION at the top of page differ from that of the first commit?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <P>
    This question refers to a port page.
    
@@ -851,12 +821,11 @@ when its Master port is updated.    This refresh updates the PORTVERSION at the 
 page.  This update reflects the REVISION you would get if you were to install the Slave port
 now that the Master has been upgraded.
 	</TD></TR>
-<TR><TD>&nbsp;</TD></TR>
 <TR id="anchors">
 <?php echo freshports_PageBannerText('What HTML anchors exist?'); ?>
 </TR>
 
-   <TR><TD>
+   <TR><TD class="textcontent">
    <p>Anchors in port pages include: </p>
 
 <ul>
@@ -898,8 +867,7 @@ now that the Master has been upgraded.
 	Enjoy. We can add more anchors upon request.
 </p>
 
-	</TD></TR><TR><TD>&nbsp;</TD></TR>
-
+	</TD></TR>
 </table>
 </td>
 

--- a/www/faq.php
+++ b/www/faq.php
@@ -35,11 +35,9 @@
 </tr>
 <TR><TD class="textcontent">
 
-<CENTER>
 <?php
-    if ($ShowAds) echo Ad_728x90();
+    if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 <P>This page contains the FAQ for FreshPorts. Hopefully the questions
 are arranged from general to specific.  The more you know, the further

--- a/www/forgotten-password.php
+++ b/www/forgotten-password.php
@@ -142,10 +142,10 @@ if (IsSet($submit)) {
 <?
 
 if (IsSet($error) and $error != '') {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+      echo '<TABLE class="fullwidth borderless">
             <TR>
             <TD>
-               <TABLE class="fullwidth borderless" CELLPADDING="1">
+               <TABLE class="fullwidth borderless">
                  <TR class="accent"><TD><b>We have a problem!</b></TD>
                  </TR> 
                  <TR>
@@ -169,10 +169,10 @@ if (IsSet($error) and $error != '') {
 } else {
 
    if ($LoginFailed || $eMailFailed) {
-      echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+      echo '<TABLE class="fullwidth borderless">
             <TR>
             <TD>
-               <TABLE class="fullwidth borderless" CELLPADDING="1">
+               <TABLE class="fullwidth borderless">
                  <TR class="accent"><TD><b>User ID not found!</b></TD>
                  </TR>
                  <TR>
@@ -211,7 +211,7 @@ if (IsSet($error) and $error != '') {
 }
 ?>
 
-<TABLE CELLPADDING="1" class="fullwidth borderless"> <TR> <TD>
+<TABLE class="fullwidth borderless"> <TR> <TD>
 
 
 <TABLE class="fullwidth borderless" CELLPADDING="5">

--- a/www/graphs.php
+++ b/www/graphs.php
@@ -39,11 +39,9 @@ If you have suggestions for graphs, please raise an issue.
 
 <HR>
 
-<center>
 <?php
-  if ($ShowAds) echo Ad_728x90();
+  if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</center>
 
 </TD></TR>
 

--- a/www/graphs2.php
+++ b/www/graphs2.php
@@ -44,11 +44,9 @@ If you have suggestions for graphs, please submit them via the <a href="<?php ec
 </P>
 
 
-<center>
 <?php
-  if ($ShowAds) echo Ad_728x90();
+  if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</center>
 
 </TD></TR>
 

--- a/www/how-big-is-it.php
+++ b/www/how-big-is-it.php
@@ -100,7 +100,7 @@ function DBSize($db) {
 	<? echo freshports_PageBannerText("How big is it"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <CENTER>
 <?php
@@ -118,19 +118,12 @@ there are.  Roughly.  This will not be 100% accurate, but it will be close.
 </TD></TR>
 
 <TR>
-<td>
-
-<?
-	echo freshports_BannerSpace();
-?>
-
-<TR>
 	<? 
 	echo freshports_PageBannerText("Pages on disk"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 First, let's count the number of pages on disk:
@@ -144,9 +137,7 @@ $Total += $Files;
 ?>
 </code></blockquote>
 
-<?
-	echo freshports_BannerSpace();
-?>
+</TD></TR>
 
 <TR>
 	<? 
@@ -154,7 +145,7 @@ $Total += $Files;
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 There is a page for each category:
@@ -172,18 +163,13 @@ echo format_number($Value) . '<br>'
 (1 row)<br>
 </code></blockquote>
 </TD></TR>
-
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("Number of ports"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 There are ports, and there are deleted ports. I'll show both:
@@ -214,17 +200,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("Number of files in the ports tree"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 There is a page for each file in the ports tree:
@@ -257,17 +239,13 @@ $Total += $Value;
 Count last performed at <?php echo $DateLastChecked; ?>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("Number of commits"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 There is a page for each commit:
@@ -286,17 +264,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("Number of ports for each commit"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 For each commit, you can view the files modified by that commit for a particular port:
@@ -315,17 +289,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("How many days?"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 For each day, there is a page showing the commits for that day.  How many days do we have?
@@ -344,17 +314,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("How many users?"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 Each user has a page:
@@ -373,17 +339,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("How many watch lists?"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 For each watch list, there is a page:
@@ -402,17 +364,13 @@ echo format_number($Value) . '<br>';
 </code></blockquote>
 </TD></TR>
 
-<?
-	echo freshports_BannerSpace();
-?>
-
 <TR>
 	<? 
 	echo freshports_PageBannerText("Estimated total"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 <?php $GooglePages = 8058044651; ?>
@@ -425,14 +383,10 @@ web pages on <a href="https://www.Google.com/">Google</a><small><sup><a href="#1
 <h2>Notes</h2>
 <ul>
 <li>These statistics are updated daily.
-<li><sup>1</sup><a name="1"></a>The number of Google pages used in this calculation is <?php echo number_format($GooglePages) ?>.
+<li id="1"><sup>1</sup>The number of Google pages used in this calculation is <?php echo number_format($GooglePages) ?>.
 </ul>
 
 </td></tr>
-
-<?
-	echo freshports_BannerSpace();
-?>
 
 <TR>
 	<? 
@@ -440,7 +394,7 @@ web pages on <a href="https://www.Google.com/">Google</a><small><sup><a href="#1
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 The total space used by the FreshPorts database is:

--- a/www/how-big-is-it.php
+++ b/www/how-big-is-it.php
@@ -102,11 +102,9 @@ function DBSize($db) {
 
 <TR><TD class="textcontent">
 
-<CENTER>
 <?php
-	if ($ShowAds) echo Ad_728x90();
+	if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 <P>
 It was a few days ago that I was thinking about search engines crawling through this website.

--- a/www/login.php
+++ b/www/login.php
@@ -227,7 +227,7 @@ if ($error) {
 
 
 
-echo '<TABLE class="fullwidth bordered" CELLPADDING="1">';
+echo '<TABLE class="fullwidth bordered">';
 
 echo '<TR>';
 

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -181,10 +181,10 @@ if (IsSet($submit)) {
 <TR><td class="content">
 <?php
 if ($errors != '') {
-echo '<TABLE CELLPADDING=1 class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD>
-<TABLE class="fullwidth borderless" CELLPADDING=1>
+<TABLE class="fullwidth borderless">
 <TR class="accent"><TD><B>Access Code Failed!</B></TD>
 </TR>
 <TR>

--- a/www/now-in-maintenance-mode.php
+++ b/www/now-in-maintenance-mode.php
@@ -55,7 +55,6 @@ This page will reload every <?php echo MAINTENANCE_MODE_RERESH_TIME_SECONDS; ?> 
 
 </TD></TR>
 
-</TD>
 </TABLE>
 </TD>
 

--- a/www/package.php
+++ b/www/package.php
@@ -70,7 +70,7 @@ The package specified ('<?php echo $packages_html; ?>') could not be found.  We 
 	$ShowPoweredBy = 1;
 ?>
 
-<TABLE class="fullwidth borderless" ALIGN="center">
+<TABLE class="fullwidth borderless">
 <TR><TD>
 <? echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/password-reset-via-token.php
+++ b/www/password-reset-via-token.php
@@ -103,10 +103,10 @@ if (IsSet($submit)) {
 
 
 if ($errors) {
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD>
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR class="accent"><TD><b>Access Code Failed!</b></TD>
 </TR>
 <TR>
@@ -137,10 +137,10 @@ if ($PasswordReset) {
 
 } else {
 
-echo '<TABLE CELLPADDING="1" class="fullwidth borderless">
+echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD VALIGN="top">
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR>
 <td class="accent"><BIG>Reset password via token</BIG></td>
 </TR>

--- a/www/pkg_process.inc
+++ b/www/pkg_process.inc
@@ -41,7 +41,7 @@ function HandleFileUpload($FormFileName, $Destination) {
 
 function DisplayError($error) {
 ?>
-	<TABLE class="fullwidth bordered" ALIGN="center" CELLPADDING="1">
+	<TABLE class="fullwidth bordered" ALIGN="center">
 	<TR><TD VALIGN=TOP>
 		<TABLE class="fullwidth">
 			<TR>

--- a/www/privacy.php
+++ b/www/privacy.php
@@ -30,11 +30,9 @@
 </TR>
 <TR><TD>
 
-<CENTER>
 <?php
-	if ($ShowAds) echo Ad_728x90();
+	if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 <P>All the information we
     gather is for our own use.  We do not release it to anyone else.</P>

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -157,7 +157,7 @@ paging to the <a href="/categories.php">categories</a> page.
 
 <p>
 You can set the paging length via  
-<a href="/customize.php">your account</> settings.
+<a href="/customize.php">your account</a> settings.
 </P>
 </TD></TR>
 
@@ -194,7 +194,7 @@ needed.
 
 </TABLE>
 
-<TABLE class="fullwidth borderless" ALIGN="center">
+<TABLE class="fullwidth borderless">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2003-04-29.php
+++ b/www/release-2003-04-29.php
@@ -29,7 +29,7 @@
 	<?php echo freshports_PageBannerText($Title); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 This is the biggest release of FreshPorts since 
 <a href="/fp2-announcement.php">FreshPorts 2</a> was released.
@@ -46,20 +46,12 @@ to this new version.
 </TD></TR>
 
 <TR>
-<td class="content"></td>
-</tr>
-
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
-<TR>
 	<?
 	echo freshports_PageBannerText("Multiple Watch Lists"); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 When FreshPorts started, a watch list was a single entity.  That was to 
@@ -76,17 +68,13 @@ me.
 
 </TD></TR>
 
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
 <TR>
 	<?
 	echo freshports_PageBannerText("Virtual categories");
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 FreshPorts now caters for virtual categories.  What's a virtual category?
@@ -111,24 +99,22 @@ description for the new category.
 
 </TD></TR>
 
-<?php echo freshports_BannerSpace(); ?>
 <TR>
 <?php echo freshports_PageBannerText("Newsfeed changes"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 The newsfeed now contains the version/revision information for the port.
 For more information on news feeds, please read the <a href="/faq.php">FAQ</a>.
 </P>
 </TD></TR>
 
-<?php echo freshports_BannerSpace(); ?>
 <TR>
 <?php echo freshports_PageBannerText("Security Notifications"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 FreshPorts has a new <a href="/report-subscriptions.php">subscription</a>
 entry.  If you subscribe to the new Security Notification report, you will
@@ -146,12 +132,11 @@ to subscribe to the announcements list for whatever software you use.
 </P>
 </TD></TR>
 
-<?php echo freshports_BannerSpace(); ?>
 <TR>
 <?php echo freshports_PageBannerText("Master websites"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 You can now view the master websites for the port.  Each
 ports has a list of websites from which their source can be downloaded.
@@ -160,12 +145,11 @@ it's never been available until now.
 </P>
 </TD></TR>
 
-<?php echo freshports_BannerSpace(); ?>
 <TR>
 <?php echo freshports_PageBannerText("Category paging"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 Some categories have a very large number of ports.  This can make loading
 the page very slow, especially for those on dial up.  Therefore, we've introduced
@@ -177,12 +161,11 @@ You can set the paging length via
 </P>
 </TD></TR>
 
-<?php echo freshports_BannerSpace(); ?>
 <TR>
 <?php echo freshports_PageBannerText("Faster pages"); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 Much work has gone into finding faster ways to extract data
 from the FreshPorts database.  Thanks to the amazing capabilities

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -185,7 +185,7 @@ the following fields.
 
 </TABLE>
 
-<TABLE class="fullwidth borderless" ALIGN="center">
+<TABLE class="fullwidth borderless">
 <TR><TD>
 <?php echo freshports_ShowFooter(); ?>
 </TD></TR>

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -53,20 +53,12 @@ and ideas which lead to the changes I've made.
 </TD></TR>
 
 <TR>
-<td class="content"></td>
-</tr>
-
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
-<TR>
 	<?
 	echo freshports_PageBannerText('Deleted icon changed'); 
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 The deleted icon has changed.  It is now <?php
@@ -75,17 +67,13 @@ well, it's been deleted.  It was a square with a X in it.
 
 </TD></TR>
 
-	<?php 
-	echo freshports_BannerSpace();
-	?>
-
 <TR>
 	<?
 	echo freshports_PageBannerText('VuXML');
 	?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 
 <P>
 The <a href="https://www.vuxml.org/freebsd/">VuXML</a> project documents
@@ -111,12 +99,11 @@ me to understand the inner workings of the vuln XML data.
 
 </TD></TR>
 
-	<?
-	echo freshports_BannerSpace();
-	echo '<tr>' . freshports_PageBannerText('Link by package') . '</tr>';
-	?>
+<TR>
+<?  echo freshports_PageBannerText('Link by package'); ?>
+</TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 You can now link to FreshPorts using just the package name.  For example, you
 can link to the Firefox port using this link:
@@ -151,12 +138,11 @@ echo '/www/firefox/</a>';
 
 </TD></TR>
 
-<?	echo freshports_BannerSpace(); ?>
 <TR>
 <?	echo freshports_PageBannerText('Revision details'); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 If you click on the Files icon (<?php echo freshports_Files_Icon(); ?>) in the
 Commit History for any port, you'll see a new link.  This link is represented
@@ -164,12 +150,11 @@ by the Revision Details icon (<?php echo freshports_Revision_Icon(); ?>).
 </P>
 </TD></TR>
 
-<?	echo freshports_BannerSpace(); ?>
 <TR>
 <?	echo freshports_PageBannerText('Expanded search options'); ?>
 </TR>
 
-<TR><TD>
+<TR><TD class="textcontent">
 <P>
 The <a href="/search.php">search page</a> now allows you to search by 
 the following fields.

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -31,11 +31,9 @@
 
 <TR><TD>
 
-<CENTER>
 <?php
-	if ($ShowAds) echo Ad_728x90();
+	if ($ShowAds) echo '<CENTER>' . Ad_728x90() . '</CENTER>';
 ?>
-</CENTER>
 
 <p>
 This page is rather dated.  Most news is now published on the

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -144,7 +144,7 @@
   <TR>
 
 <TD class="content">
-<TABLE class="fullwidth borderless" CELLPADDING="1">
+<TABLE class="fullwidth borderless">
 <TR>
 <td class="accent"><BIG><? echo $ArticleTitle; ?></BIG></td>
 </TR>

--- a/www/vuxml.php
+++ b/www/vuxml.php
@@ -24,7 +24,7 @@
 		$vidArray = explode('|', $vid);
 	}
 ?>
-<html>
+<html lang="en">
 <head>
 <title>FreshPorts - VuXML</title>
 <meta name="robots" content="nofollow">


### PR DESCRIPTION
- Cleans up the commit list a bit to not include deprecated `<big>` elements, and `<small>` elements (which aren't deprecated but now reserved for more specific usage than what we're using them for)
- Clean up some usage of the `cellpadding` attribute that was setting it to the default value (use of this attribute is deprecated)
- Stop using empty table rows/cells to create whitespace in the more prose-heavy pages like FAQ, How Big is It, and About pages, use CSS classes & padding instead
- Tidy up some of the ads code to only conditionally display `<center>` elements (deprecated, will clean up properly later)
- Remove some use of the `align` element (deprecated attribute)
- Mark HTML language as English (solves a warning in HTML5 validation, should be better for SEO & accessibility)
- Some other random HTML fixes

With this we're valid HTML5 if we switch the doctype over for a bunch of pages, including the homepage.

Pages needing more work to reach that status include:
- categories page
- backend/newsfeeds page
- graphs & graph2
- individual port pages
- individual category pages
- individual commit pages