### PR TITLE
HTML Cleanup: Category list & Category pages

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -170,7 +170,7 @@ class port_display {
 		if (defined('PKG_MESSAGE_UCL') && PKG_MESSAGE_UCL && $this->_isUCL($port->pkgmessage)) {
 			$HTML .= $this->_pkgmessage_UCL($port->pkgmessage);
 		} else {
-			$HTML .= '<dt><b>pkg-message:</b></dt>' . "\n" . '<dd class="like-pre">';
+			$HTML .= "<dt><b>pkg-message:</b></dt>\n" . '<dd class="like-pre">';
 			$HTML .= htmlspecialchars($port->pkgmessage);
 			$HTML .= "</dd>\n</dl>\n<hr>\n<dl>";
 		}
@@ -730,7 +730,7 @@ class port_display {
 					$HTML .= ' (' . freshports_Search_Committer($port->committer_name) . ')';
 				}
 
-				$HTML .= ' on <font size="-1">' . $port->updated . '</font>' . "\n";
+				$HTML .= ' on ' . $port->updated . "\n";
 
 				$HTML .= freshports_Email_Link($port->message_id);
 
@@ -756,31 +756,31 @@ class port_display {
 		# show the date added, if asked
 
 		if ($this->ShowDateAdded || $this->ShowEverything) {
-			$HTML .= '<dt><b>Port Added:</b> <font size="-1">';
+			$HTML .= '<dt><b>Port Added:</b> ';
 			if ($port->date_added) {
 				$HTML .= FormatTime($port->date_added, 0, "Y-m-d H:i:s");
 			} else {
 				$HTML .= "unknown";
 			}
-			$HTML .= '</font></dt>' . "\n";
+			$HTML .= "</dt>\n";
 		}
 
 		# show the date modified, if asked
 
 		if ($this->ShowLastCommitDate || $this->ShowEverything) {
-			$HTML .= '<dt><b>Last Update:</b> <font size="-1">';
+			$HTML .= '<dt><b>Last Update:</b> ';
 			if ($port->last_commit_date) {
 				$HTML .= FormatTime($port->last_commit_date, 0, "Y-m-d H:i:s");
 			} else {
 				$HTML .= "unknown";
 			}
-			$HTML .= '</font></dt>' . "\n";
+			$HTML .= "</dt>\n";
 
 			if (strpos($port->message_id, 'freebsd.org') === false) {
-				$HTML .= '<dt><b>Commit Hash:</b> <font size="-1">';
+				$HTML .= '<dt><b>Commit Hash:</b> ';
 				$HTML .= freshports_git_commit_Link_Hash($port->svn_revision, $port->commit_hash_short, $port->repo_hostname, $port->path_to_repo);
 			} else {
-				$HTML .= '<dt><b>SVN Revision:</b> <font size="-1">';
+				$HTML .= '<dt><b>SVN Revision:</b> ';
 				if (isset($port->svn_revision)) {
 					$HTML .= freshports_svnweb_ChangeSet_Link_Text($port->svn_revision, $port->repo_hostname);
 				} else {
@@ -788,7 +788,7 @@ class port_display {
 			        }
 			}
 
-			$HTML .= '</font></dt>' . "\n";
+			$HTML .= "</dt>\n";
 		}
 
 		if ($this->ShowEverything || $this->ShowBasicInfo) {
@@ -1026,7 +1026,7 @@ class port_display {
 						$HTML .= '</dd>';
 					}
 				} else {
-					$HTML .= '<dd>There is no distinfo for this port.</dd>' . "\n";
+					$HTML .= "<dd>There is no distinfo for this port.</dd>\n";
 				}
 			}
 
@@ -1088,7 +1088,7 @@ class port_display {
 				$HTML .= '</dd>';
 
 			} else {
-				$HTML .= '<dd>No package information in database for this port.</dd>' . "\n";
+				$HTML .= "<dd>No package information in database for this port.</dd>\n";
 			}
 		}
 

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -641,12 +641,14 @@ class port_display {
 			if ($port->IsSlavePort()) $HTML .= ' NOTE: Slave port - quarterly revision is most likely wrong.';
 			$HTML .= '</span></span>';
 		}
+		if ($this->ShowEverything || $this->ShowShortDescription || $this->ShowCategory) {
+			// this dt was opened before all the icons, just before the start of the version number
+			$HTML .= '</dt>';
+		}
 
 		# if you add content to this IF statement, you may need to addition more conditions to the if
 		if (($this->ShowEverything || $this->ShowBasicInfo) && 
 		    ($port->forbidden || $port->broken || $port->deprecated || $port->expiration_date || $port->ignore || $port->restricted || $port->no_cdrom || $port->is_interactive)) {
-
-			$HTML .= "<dt>\n";
 
 			# various details about this port
 			$HTML .= "<dd>";
@@ -699,16 +701,16 @@ class port_display {
 				         'Ports mailing list via ';
 				$HTML .= '<A HREF="' . MAILTO . ':' . freshportsObscureHTML($port->maintainer);
 				$HTML .= '?subject=FreeBSD%20Port:%20' . $port->category . '/' . $port->port . '" TITLE="email the FreeBSD Ports mailing list">';
-				$HTML .= freshportsObscureHTML($port->maintainer) . '</A></dd>';
+				$HTML .= freshportsObscureHTML($port->maintainer) . '</A> ' . freshports_Search_Maintainer($port->maintainer) . '</dd>';
 			} else {
 				$HTML .= '<dt><b>';
 
 				$HTML .= 'Maintainer:</b> <A HREF="' . MAILTO . ':' . freshportsObscureHTML($port->maintainer);
 				$HTML .= '?subject=FreeBSD%20Port:%20' . $port->category . '/' . $port->port . '" TITLE="email the maintainer">';
-				$HTML .= freshportsObscureHTML($port->maintainer) . '</A>';
+				$HTML .= freshportsObscureHTML($port->maintainer) . '</A> ';
+				$HTML .= freshports_Search_Maintainer($port->maintainer) . '</dt>';
 			}
 
-			$HTML .= ' ' . freshports_Search_Maintainer($port->maintainer) . '</dt>';
 		}
 
 		// there are only a few places we want to show the last change.
@@ -820,10 +822,9 @@ class port_display {
 						}
 						$OtherCategories .= '">' . $Category . '</a> ';
 					}
-					$HTML .= "</dt>\n";
 
 					# get rid of that trailing space from above.
-					$HTML .= rtrim($OtherCategories);
+					$HTML .= rtrim($OtherCategories) . "</dt>\n";
 				}
 			}
 

--- a/include/constants.php
+++ b/include/constants.php
@@ -201,3 +201,5 @@ const SEARCH_SELECT_FIELD = '
 const HASH_UPDATE_QUERY = 'HASH_UPDATE';
 if (!defined('PW_HASH_METHOD')) define('PW_HASH_METHOD', 'bf');
 if (!defined('PW_HASH_COST')) define('PW_HASH_COST', 14);
+
+define('HTML_DOCTYPE', '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">');

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -135,9 +135,8 @@ function freshports_Search_Committer($Committer) {
 	      freshports_Search_Icon('search for other commits by this committer') . '</a>';
 }
 
-function freshports_MainContentTable($Classes=BORDER, $ColSpan=1) {
-	return '<table class="maincontent fullwidth ' . $Classes . '">' .
-		PortsFreezeStatus($ColSpan);
+function freshports_MainContentTable($Classes=BORDER) {
+	return '<table class="maincontent fullwidth ' . $Classes . '">' . PortsFreezeStatus();
 }
 
 function  freshports_ErrorContentTable() {
@@ -146,7 +145,7 @@ function  freshports_ErrorContentTable() {
 }
 
 
-function PortsFreezeStatus($ColSpan=1) {
+function PortsFreezeStatus() {
 	#
 	# this function checks to see if there is a port freeze on.
 	# if there is, it returns text that indicates same.
@@ -156,12 +155,9 @@ function PortsFreezeStatus($ColSpan=1) {
 
 	if (file_exists(SIGNALS_DIRECTORY . "/PortsFreezeIsOn")) {
 		$result = '
-<tr>' . freshports_PageBannerText('There is a PORTS FREEZE in effect!', $ColSpan) . '</tr>
-<tr><td';
-		if ($ColSpan > 1) {
-			$result .= ' colspan="' . $ColSpan . '"';
-		}
-		$result .= '>
+<tr>' . freshports_PageBannerText('There is a PORTS FREEZE in effect!') . '</tr>
+<tr><td>';
+		$result .= '
 <p>A <a href="https://www.freebsd.org/doc/en/articles/committers-guide/ports.html" rel="noopener noreferrer">ports freeze</a>
  means that commits will be few and far between and only by approval.
 </p>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1024,16 +1024,6 @@ function freshports_Category_Name($CategoryID, $db) {
 	return $myrow["name"];
 }
 
-
-function freshports_echo_HTML($text) {
-//   echo $text;
-   return $text;
-}
-
-function freshports_echo_HTML_flush() {
-#   echo $HTML_Temp;
-}
-
 function freshports_in_array($value, $array) {
   $Count = count($array);
   for ($i = 0; $i < $Count; $i++) {

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -859,7 +859,7 @@ $HTML .= '
 function freshports_HTML_Start() {
 GLOBAL $Debug;
 
-echo '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+echo HTML_DOCTYPE . '
 <html lang="en">
 ';
 }

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -7,6 +7,7 @@
 
 	set_include_path('/usr/local/share/pear');
 	require_once("HTML/Page2.php");
+	require_once('constants.php');
 
 class freshports_page extends HTML_Page2 {
 
@@ -27,7 +28,7 @@ class freshports_page extends HTML_Page2 {
 
 		$this->HTML_Page2($attributes);
 
-		$this->setMetaData('author',           'Dan Langille');
+		$this->setMetaData('author',           COPYRIGHTHOLDER);
 		$this->setMetaData('description',      'FreshPorts - new ports, applications');
 		$this->setMetaData('keywords',         'FreeBSD, index, applications, ports');
 
@@ -104,5 +105,11 @@ class freshports_page extends HTML_Page2 {
 
 	function setDebug($Debug) {
 		$this->_debug = $Debug;
+	}
+
+	function _getDoctype() {
+		// HTML_Page2 generates inconsistent doctype with the rest of the site
+		// Since we're in quirks mode this breaks the styles for some pages
+		return HTML_DOCTYPE;
 	}
 }

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -202,7 +202,7 @@ $category->description . '
 
 <p>
 	Ports marked with a <sup>*</sup> actually reside within another category but
-	have <b>' . $category->name . '</b> listed as a secondary category.';
+	have <strong>' . $category->name . '</strong> listed as a secondary category.';
 
 		GLOBAL $ShowAds, $BannerAd;
 
@@ -210,7 +210,7 @@ $category->description . '
 			$HTML .= "<br><center>\n" . Ad_728x90() . "\n</center>\n";
 		}
 
-		$HTML .= '<div align="center"><br>' . 
+		$HTML .= '<div class="pagination">' .
 			freshports_CategoryNextPreviousPage($category->name, $PortCount, $PageNumber, $PageSize, $Branch)  . 
 			'</div>';
 
@@ -245,7 +245,7 @@ $category->description . '
 		$HTML .= '
 </TD></TR>
 <TR><TD>
-<div align="center"><br>' . 
+<div class="pagination">' .
 
 			freshports_CategoryNextPreviousPage($category->name, $PortCount, $PageNumber, $PageSize, $Branch) . '
 
@@ -286,8 +286,6 @@ if ($ShowAds && $BannerAd) {
 	echo "<br><center>\n" . Ad_728x90() . "\n</center>\n";
 }
 ?>
-
-	</td></tr>
 
 <?php
 

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -196,9 +196,9 @@ function freshports_CategoryDisplay($db, $category, $PageNumber = 1, $PageSize =
 
 
 		$HTML .= '
-<BIG><BIG><B>' . 
+<span class="element-details"><span>' .
 $category->description . '
-</B></BIG></BIG>- Number of ports in this category' . ($Branch == BRANCH_HEAD ? '' : ' with commits on branch ' . pg_escape_string($Branch)) . ': ' . $PortCount . '
+</span></span> - Number of ports in this category' . ($Branch == BRANCH_HEAD ? '' : ' with commits on branch ' . pg_escape_string($Branch)) . ': ' . $PortCount . '
 
 <p>
 	Ports marked with a <sup>*</sup> actually reside within another category but

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -224,7 +224,7 @@ $category->description . '
 
 		$ShowShortDescription	= "Y";
 
-		$HTML .= freshports_echo_HTML("<TR>\n<TD>\n");
+		$HTML .= "<TR>\n<TD>\n";
 
 		require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/port-display.php');
 

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -185,7 +185,7 @@ function freshports_CategoryDisplay($db, $category, $PageNumber = 1, $PageSize =
 
 	<tr><td>';
 
-		if ($category->IsPrimary()) {
+		if ($category->IsPrimary() && $User->id) {
 			if ($WatchListCount) {
 				$HTML .= freshports_Watch_Link_Remove('', 0, $category->element_id);
 			} else {

--- a/www/categories.php
+++ b/www/categories.php
@@ -57,12 +57,12 @@
 
 <tr><td class="content">
 
-<?php echo freshports_MainContentTable(BORDER, $ColSpan); ?>
+<?php echo freshports_MainContentTable(BORDER + ' category-list', $ColSpan); ?>
 
   <tr>
 	<? echo freshports_PageBannerText("$FreshPortsTitle - list of categories", $ColSpan); ?>
   </tr>
-<tr><td COLSPAN="<?php echo $ColSpan; ?>" valign="top">
+<tr><td COLSPAN="<?php echo $ColSpan; ?>">
 <P>
 This page lists the categories and can be sorted by various criteria.  Virtual
 categories are indicated by <?php echo VIRTUAL; ?>.
@@ -161,7 +161,7 @@ if (!$result) {
       for ($i = 0; $i < $NumRows; $i++) {
         $myrow = pg_fetch_array($result, $i);
 		$HTML .= '<tr>';
-		$HTML .= '<td align="top" nowrap>';
+		$HTML .= '<td nowrap>';
         if ($User->id) {
           if ($Primary[$myrow["is_primary"]]) {
             $HTML .= freshports_Watch_Icon_Empty();
@@ -179,12 +179,12 @@ if (!$result) {
 		
 		$HTML .= '</td>';
 		if ($AllowedToEdit) {
-			$HTML .= '<td valign="top"><a href="/category-maintenance.php?category=' . $myrow["category"] . '">update</a></td>';
+			$HTML .= '<td><a href="/category-maintenance.php?category=' . $myrow["category"] . '">update</a></td>';
 		}
 
-		$HTML .= '<td valign="top" ALIGN="right">' . $myrow["count"] . '</td>';
-		$HTML .= '<td valign="top">' . $myrow["description"] . '</td>';
-		$HTML .= '<td valign="top" nowrap>' . $myrow["lastupdate"] . '</td>';
+		$HTML .= '<td ALIGN="right">' . $myrow["count"] . '</td>';
+		$HTML .= '<td>' . $myrow["description"] . '</td>';
+		$HTML .= '<td nowrap>' . $myrow["lastupdate"] . '</td>';
 		$HTML .= "</tr>\n";
 
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -184,7 +184,7 @@ if (!$result) {
 
 		$HTML .= '<td valign="top" ALIGN="right">' . $myrow["count"] . '</td>';
 		$HTML .= '<td valign="top">' . $myrow["description"] . '</td>';
-		$HTML .= '<td valign="top" nowrap><font size="-1">' . $myrow["lastupdate"] . '</font></td>';
+		$HTML .= '<td valign="top" nowrap>' . $myrow["lastupdate"] . '</td>';
 		$HTML .= "</tr>\n";
 
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -57,19 +57,19 @@
 
 <tr><td class="content">
 
-<?php echo freshports_MainContentTable(BORDER + ' category-list', $ColSpan); ?>
+<?php echo freshports_MainContentTable(BORDER); ?>
 
   <tr>
-	<? echo freshports_PageBannerText("$FreshPortsTitle - list of categories", $ColSpan); ?>
+	<? echo freshports_PageBannerText("$FreshPortsTitle - list of categories"); ?>
   </tr>
-<tr><td COLSPAN="<?php echo $ColSpan; ?>">
+<tr><td>
 <P>
 This page lists the categories and can be sorted by various criteria.  Virtual
 categories are indicated by <?php echo VIRTUAL; ?>.
 </P>
 
 <P>
-You can sort each column by clicking on the header.  e.g. click on <b>Category</b> to sort by category.
+You can sort each column by clicking on the header.  e.g. click on <strong>Category</strong> to sort by category.
 </P>
 
 <?php
@@ -78,6 +78,7 @@ You can sort each column by clicking on the header.  e.g. click on <b>Category</
   }
 ?>
 
+<table class="category-list fullwidth bordered">
 
 <?php
 $sort = IsSet($_REQUEST['sort']) ? pg_escape_string($_REQUEST['sort']) : '';
@@ -130,27 +131,27 @@ if ($AllowedToEdit) {
 	
 
 if ($sort == "count") {
-   $HTML .= '<th align="center">Count ' . freshports_Ascending_Icon() . '</th>';
+   $HTML .= '<th>Count ' . freshports_Ascending_Icon() . '</th>';
 } else {
    $HTML .= '<th><a href="categories.php?sort=count">Count</a></th>';
 }
 
 if ($sort == "description") {
-   $HTML .= '<th>Description ' . freshports_Ascending_Icon() . '</td>';
+   $HTML .= '<th>Description ' . freshports_Ascending_Icon() . '</th>';
 } else {
    $HTML .= '<th><a href="categories.php?sort=description">Description</a></th>';
 }
 
 if ($sort == "last_update") {
-   $HTML .= '<th nowrap>Last Update ' . freshports_Ascending_Icon() . '</th>';
+   $HTML .= '<th>Last Update ' . freshports_Ascending_Icon() . '</th>';
 } else {
-   $HTML .= '<th nowrap><a href="categories.php?sort=lastupdate">Last Update</a></th>';
+   $HTML .= '<th><a href="categories.php?sort=lastupdate">Last Update</a></th>';
 }
 
 $HTML .= '</tr>';
 
 if (!$result) {
-   echo "<tr><td colspan=\"$ColSpan\"" . pg_errormessage() . "</td></tr></table>\n";
+   echo "<tr><td colspan=\"$ColSpan\"" . pg_errormessage() . "</td></tr></table></td></td></table>\n";
    exit;
 } else {
 	$NumTopics	   = 0;
@@ -161,7 +162,7 @@ if (!$result) {
       for ($i = 0; $i < $NumRows; $i++) {
         $myrow = pg_fetch_array($result, $i);
 		$HTML .= '<tr>';
-		$HTML .= '<td nowrap>';
+		$HTML .= '<td>';
         if ($User->id) {
           if ($Primary[$myrow["is_primary"]]) {
             $HTML .= freshports_Watch_Icon_Empty();
@@ -184,7 +185,7 @@ if (!$result) {
 
 		$HTML .= '<td ALIGN="right">' . $myrow["count"] . '</td>';
 		$HTML .= '<td>' . $myrow["description"] . '</td>';
-		$HTML .= '<td nowrap>' . $myrow["lastupdate"] . '</td>';
+		$HTML .= '<td>' . $myrow["lastupdate"] . '</td>';
 		$HTML .= "</tr>\n";
 
 
@@ -209,7 +210,7 @@ $HTML .= "<td ALIGN=\"right\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryC
 
 $HTML .= "<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>";
 
-$HTML .= '</table>';
+$HTML .= '</table></td></tr></table>';
 
 echo $HTML;                                                   
 ?>

--- a/www/categories.php
+++ b/www/categories.php
@@ -118,33 +118,33 @@ $result = pg_exec($db, $sql);
 $HTML = '<tr>';
 
 if ($sort == "category") {
-   $HTML .= '<td><b>Category</b> ' . freshports_Ascending_Icon() . '</td>';
+   $HTML .= '<th>Category ' . freshports_Ascending_Icon() . '</th>';
 } else {
-   $HTML .= '<td><a href="categories.php?sort=category"><b>Category<b></a></td>';
+   $HTML .= '<th><a href="categories.php?sort=category">Category</a></th>';
 }
 
 
 if ($AllowedToEdit) {
-	$HTML .= '<td><b>Action</b></td>';
+	$HTML .= '<th>Action</th>';
 }
 	
 
 if ($sort == "count") {
-   $HTML .= '<td align="center"><b>Count</b> ' . freshports_Ascending_Icon() . '</td>';
+   $HTML .= '<th align="center">Count ' . freshports_Ascending_Icon() . '</th>';
 } else {
-   $HTML .= '<td><a href="categories.php?sort=count"><b>Count</b></a></td>';
+   $HTML .= '<th><a href="categories.php?sort=count">Count</a></th>';
 }
 
 if ($sort == "description") {
-   $HTML .= '<td><b>Description</b> ' . freshports_Ascending_Icon() . '</td>';
+   $HTML .= '<th>Description ' . freshports_Ascending_Icon() . '</td>';
 } else {
-   $HTML .= '<td><a href="categories.php?sort=description"><b>Description</b></a></td>';
+   $HTML .= '<th><a href="categories.php?sort=description">Description</a></th>';
 }
 
 if ($sort == "last_update") {
-   $HTML .= '<td nowrap><b>Last Update</b> ' . freshports_Ascending_Icon() . '</td>';
+   $HTML .= '<th nowrap>Last Update ' . freshports_Ascending_Icon() . '</th>';
 } else {
-   $HTML .= '<td nowrap><a href="categories.php?sort=lastupdate"><b>Last Update</b></a></td>';
+   $HTML .= '<th nowrap><a href="categories.php?sort=lastupdate">Last Update</a></th>';
 }
 
 $HTML .= '</tr>';

--- a/www/categories.php
+++ b/www/categories.php
@@ -183,7 +183,7 @@ if (!$result) {
 			$HTML .= '<td><a href="/category-maintenance.php?category=' . $myrow["category"] . '">update</a></td>';
 		}
 
-		$HTML .= '<td ALIGN="right">' . $myrow["count"] . '</td>';
+		$HTML .= '<td class="numeric-cell">' . $myrow["count"] . '</td>';
 		$HTML .= '<td>' . $myrow["description"] . '</td>';
 		$HTML .= '<td>' . $myrow["lastupdate"] . '</td>';
 		$HTML .= "</tr>\n";
@@ -206,7 +206,7 @@ if ($AllowedToEdit) {
 	$HTML .= '<td>&nbsp;</td>';
 }
 
-$HTML .= "<td ALIGN=\"right\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>";
+$HTML .= "<td class=\"numeric-cell\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>";
 
 $HTML .= "<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>";
 

--- a/www/categories.php
+++ b/www/categories.php
@@ -115,39 +115,39 @@ if ($Debug) echo '<pre>' . $sql, "</pre>\n";
 
 $result = pg_exec($db, $sql);
 
-$HTML = freshports_echo_HTML('<tr>');
+$HTML = '<tr>';
 
 if ($sort == "category") {
-   $HTML .= freshports_echo_HTML('<td><b>Category</b> ' . freshports_Ascending_Icon() . '</td>');
+   $HTML .= '<td><b>Category</b> ' . freshports_Ascending_Icon() . '</td>';
 } else {
-   $HTML .= freshports_echo_HTML('<td><a href="categories.php?sort=category"><b>Category<b></a></td>');
+   $HTML .= '<td><a href="categories.php?sort=category"><b>Category<b></a></td>';
 }
 
 
 if ($AllowedToEdit) {
-	$HTML .= freshports_echo_HTML('<td><b>Action</b></td>');
+	$HTML .= '<td><b>Action</b></td>';
 }
 	
 
 if ($sort == "count") {
-   $HTML .= freshports_echo_HTML('<td align="center"><b>Count</b> ' . freshports_Ascending_Icon() . '</td>');
+   $HTML .= '<td align="center"><b>Count</b> ' . freshports_Ascending_Icon() . '</td>';
 } else {
-   $HTML .= freshports_echo_HTML('<td><a href="categories.php?sort=count"><b>Count</b></a></td>');
+   $HTML .= '<td><a href="categories.php?sort=count"><b>Count</b></a></td>';
 }
 
 if ($sort == "description") {
-   $HTML .= freshports_echo_HTML('<td><b>Description</b> ' . freshports_Ascending_Icon() . '</td>');
+   $HTML .= '<td><b>Description</b> ' . freshports_Ascending_Icon() . '</td>';
 } else {
-   $HTML .= freshports_echo_HTML('<td><a href="categories.php?sort=description"><b>Description</b></a></td>');
+   $HTML .= '<td><a href="categories.php?sort=description"><b>Description</b></a></td>';
 }
 
 if ($sort == "last_update") {
-   $HTML .= freshports_echo_HTML('<td nowrap><b>Last Update</b> ' . freshports_Ascending_Icon() . '</td>');
+   $HTML .= '<td nowrap><b>Last Update</b> ' . freshports_Ascending_Icon() . '</td>';
 } else {
-   $HTML .= freshports_echo_HTML('<td nowrap><a href="categories.php?sort=lastupdate"><b>Last Update</b></a></td>');
+   $HTML .= '<td nowrap><a href="categories.php?sort=lastupdate"><b>Last Update</b></a></td>';
 }
 
-$HTML .= freshports_echo_HTML('</tr>');
+$HTML .= '</tr>';
 
 if (!$result) {
    echo "<tr><td colspan=\"$ColSpan\"" . pg_errormessage() . "</td></tr></table>\n";
@@ -160,7 +160,7 @@ if (!$result) {
     if ($NumRows) {
       for ($i = 0; $i < $NumRows; $i++) {
         $myrow = pg_fetch_array($result, $i);
-		$HTML .= freshports_echo_HTML('<tr>');
+		$HTML .= '<tr>';
 		$HTML .= '<td align="top" nowrap>';
         if ($User->id) {
           if ($Primary[$myrow["is_primary"]]) {
@@ -175,17 +175,17 @@ if (!$result) {
 		}
 		$HTML .= ' ';
 
-		$HTML .= freshports_echo_HTML('<a href="/' . $myrow["category"] . '/">' . $myrow["category"] . '</a>' . $Primary[$myrow["is_primary"]]);
+		$HTML .= '<a href="/' . $myrow["category"] . '/">' . $myrow["category"] . '</a>' . $Primary[$myrow["is_primary"]];
 		
 		$HTML .= '</td>';
 		if ($AllowedToEdit) {
-			$HTML .= freshports_echo_HTML('<td valign="top"><a href="/category-maintenance.php?category=' . $myrow["category"] . '">update</a></td>');
+			$HTML .= '<td valign="top"><a href="/category-maintenance.php?category=' . $myrow["category"] . '">update</a></td>';
 		}
 
-		$HTML .= freshports_echo_HTML('<td valign="top" ALIGN="right">' . $myrow["count"] . '</td>');
-		$HTML .= freshports_echo_HTML('<td valign="top">' . $myrow["description"] . '</td>');
-		$HTML .= freshports_echo_HTML('<td valign="top" nowrap><font size="-1">' . $myrow["lastupdate"] . '</font></td>');
-		$HTML .= freshports_echo_HTML("</tr>\n");
+		$HTML .= '<td valign="top" ALIGN="right">' . $myrow["count"] . '</td>';
+		$HTML .= '<td valign="top">' . $myrow["description"] . '</td>';
+		$HTML .= '<td valign="top" nowrap><font size="-1">' . $myrow["lastupdate"] . '</font></td>';
+		$HTML .= "</tr>\n";
 
 
 		# count only the ports in primary categories
@@ -200,18 +200,16 @@ if (!$result) {
     }
 }
 
-$HTML .= freshports_echo_HTML('<tr><td><b>port count:</b></td>');
+$HTML .= '<tr><td><b>port count:</b></td>';
 if ($AllowedToEdit) {
-	$HTML .= freshports_echo_HTML('<td>&nbsp;</td>');
+	$HTML .= '<td>&nbsp;</td>';
 }
 
-$HTML .= freshports_echo_HTML("<td ALIGN=\"right\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>");
+$HTML .= "<td ALIGN=\"right\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>";
 
-$HTML .= freshports_echo_HTML("<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>");
+$HTML .= "<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>";
 
-$HTML .= freshports_echo_HTML('</table>');
-
-freshports_echo_HTML_flush();
+$HTML .= '</table>';
 
 echo $HTML;                                                   
 ?>

--- a/www/categories.php
+++ b/www/categories.php
@@ -201,12 +201,12 @@ if (!$result) {
     }
 }
 
-$HTML .= '<tr><td><b>port count:</b></td>';
+$HTML .= '<tr><td class="summary-cell">port count:</td>';
 if ($AllowedToEdit) {
 	$HTML .= '<td>&nbsp;</td>';
 }
 
-$HTML .= "<td class=\"numeric-cell\"><b>$NumPorts</b></td><td colspan=\"2\">($CategoryCount categories)</td></tr>";
+$HTML .= "<td class=\"numeric-cell summary-cell\">$NumPorts</td><td colspan=\"2\">($CategoryCount categories)</td></tr>";
 
 $HTML .= "<tr><td colspan=\"$ColSpan\">Hmmm, I'm not so sure this port count is accurate. Dan Langille 27 April 2003</td></tr>";
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -114,6 +114,10 @@ table.maincontent td.textcontent {
   vertical-aligN: top;
 }
 
+td.numeric-cell {
+  text-align: right;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -118,6 +118,10 @@ td.numeric-cell {
   text-align: right;
 }
 
+td.summary-cell {
+  font-weight: bold;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -104,6 +104,12 @@ table.maincontent td.textcontent {
   vertical-align: top;
 }
 
+.category-list th {
+  text-align: left;
+  font-weight: bold;
+  vertical-aligN: top;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -122,6 +122,11 @@ td.summary-cell {
   font-weight: bold;
 }
 
+.pagination {
+  margin: 1em auto 0;
+  text-align: center;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -100,8 +100,12 @@ table.maincontent td.textcontent {
   padding-bottom: 2em;
 }
 
-.category-list td:not(.accent) {
+.category-list td {
   vertical-align: top;
+}
+
+.category-list td:last-child, .category-list th:last-child {
+  white-space: nowrap;
 }
 
 .category-list th {

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -100,6 +100,10 @@ table.maincontent td.textcontent {
   padding-bottom: 2em;
 }
 
+.category-list td:not(.accent) {
+  vertical-align: top;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}


### PR DESCRIPTION
- A bit of cleanup on the categories page to get valid HTML5 (this also adds a nested a table, since when we do eventually remove the main tables this list will actually remain as a table I think)
- Similar cleanup on the individual Category pages
- Tweak to how the pages generated with `HTML/Page2` pick a doctype to make it consistent with all the other pages (its different doctype was making those pages use different styles)
- Don't show the add to watchlist button on the category page if the user isn't logged in, like the rest of the site

With this we're valid HTML5 if we switch the doctype over for a bunch more pages.

Pages needing more work to reach that status include:

- backend/newsfeeds page
- graphs & graph2
- individual port pages
- individual commit pages
