### PR TITLE
Rewrite Cleanup

### DIFF
--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -35,7 +35,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	$Debug  = 0;
 	$result = false;
 
-	$IsPort     = false;
 	$IsCategory = false;
 	$IsElement  = false;
 	$HasCommitsOnBranch = false;
@@ -94,12 +93,12 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	define('PATH_NAME', $pathname);
 	if ($Debug) echo "PATH_NAME='" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
-	# let's see if this is a category.
+	# let's see if this exists on the target branch
 	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, false)) {
 		$IsElement = true;
 		if ($Debug) echo 'we found an element for that<br>';
 		if ($Debug) echo "we have: '$ElementRecord->element_pathname'<br>";
-		if ($Debug) echo " we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
+		if ($Debug) echo "we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
 		# in a case insensitive search, we want to redirect if the case was wrong
 		if (PathnameDiffers($ElementRecord->element_pathname, FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME)) {
@@ -118,9 +117,9 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo 'we found an element for that, therefore, there must be commits!<br>';
 			$HasCommitsOnBranch = true; // this is true even if the branch is head
 		}
+	# okay, let's try on head...
 	} else if ($Branch != BRANCH_HEAD) {	
 		if ($Debug) echo 'trying on head next<br>';
-		# if this is not a category, let's check for details on what might be a port
 		if ($Debug) echo 'checking ' . FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME . ' to see what we find<br>';
 		if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME, false)) {
 			# again, we want to fix the case if it's wrong
@@ -132,7 +131,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			}
 			$IsElement          = true;
 			$HasCommitsOnBranch = false; // we had to fall back to head to find this element
-			$IsCategory = $ElementRecord->IsCategory();
+			$IsCategory         = $ElementRecord->IsCategory();
 		}
 	} else {
 		if ($Debug) echo 'we found no element for that.<br>';
@@ -157,8 +156,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 
 		if ($ElementRecord->IsPort()) {
-			$IsPort = true;
-
 			# we don't use list($category, $port) so we don't have to worry
 			# about extra bits
 			$PathParts = explode('/', PATH_NAME);
@@ -227,16 +224,13 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "Port is '$port'<br>";
 		}
 
-		if (IsSet($port)) {
-			$result = $REQUEST_URI;
-			if ($Debug) echo 'This is a Port but there is no element for it.<br>';
-		}
+		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';}
 
 		if (IsSet($category)) {
 			# we have a valid category, but no valid port.
-			# we will display the category only if they did *try* to speciy a port.
-			# i.e. they suuplied an invalid port name
-			if ($Debug) echo 'This is a category &&&<br>';
+			# we will display the category only if they did *try* to specify a port.
+			# i.e. they supplied an invalid port name
+			if ($Debug) echo 'This is a category <br>';
 
 			if (IsSet($port)) {
 				if ($Debug)  'Invalid port supplied for a valid category<br>';

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -118,7 +118,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			$HasCommitsOnBranch = true; // this is true even if the branch is head
 		}
 	# okay, let's try on head...
-	} else if ($Branch != BRANCH_HEAD) {	
+	} else if ($Branch != BRANCH_HEAD) {
 		if ($Debug) echo 'trying on head next<br>';
 		if ($Debug) echo 'checking ' . FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME . ' to see what we find<br>';
 		if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME, false)) {
@@ -217,7 +217,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "Port is '$port'<br>";
 		}
 
-		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';}
+		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';
 
 		if (IsSet($category)) {
 			# we have a valid category, but no valid port.

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -7,7 +7,6 @@ function PathnameDiffers($Path1, $Path2) {
 }
 
 function freshports_Parse404URI($REQUEST_URI, $db) {
-	#
 	# we have a pending 404
 	# if we can parse it, then do so and return a false value;
 	# otherwise, return a non-false value.
@@ -15,20 +14,19 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	GLOBAL $User;
 
 	$Debug  = 0;
-	$result = '';
+	$result = false;
 
 	$IsPort     = false;
 	$IsCategory = false;
 	$IsElement  = false;
 	$HasCommitsOnBranch = false;
+	$CategoryID = 0;
 
 	if ($Debug) {
 		echo "Debug is turned on.  Only 404 will be returned now because we cannot alter the headers at this time.<br>\n";
 		echo "\$REQUEST_URI='$REQUEST_URI'<br>";
 		phpinfo();
 	}
-
-	$CategoryID = 0;
 
 	$URLParts = parse_url($_SERVER['REQUEST_URI']);
 	if ($Debug)

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -148,6 +148,27 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "This is a port!<br>";
 			if ($Debug) echo "Category='$category'<br>";
 			if ($Debug) echo "Port='$port'<br>";
+
+			if ($Debug) echo 'including missing-port<BR>';
+			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-port.php');
+
+			if ($Debug) echo 'including missing-port<BR>';
+
+			if ($HasCommitsOnBranch) {
+				# if zero is returned, all is well, otherwise, we can't display that category/port.
+				if ($Debug) echo 'invoking freshports_PortDisplay<br>';
+				if (freshports_PortDisplay($db, $category, $port, $Branch)) {
+					echo 'freshports_PortDisplay returned non-zero';
+					return -1;
+				}
+			} else {
+				# if zero is returned, all is well, otherwise, we can't display that category/port.
+				if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
+				if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
+					echo 'freshports_PortDisplay returned non-zero';
+					return -1;
+				}
+			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
 		}
@@ -184,13 +205,11 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 
 		if (IsSet($port)) {
-			$IsPort = false;
 			$result = $REQUEST_URI;
-
 			if ($Debug) echo 'This is a Port but there is no element for it.<br>';
 		}
 
-		if (IsSet($category) && !$IsPort) {
+		if (IsSet($category)) {
 			# we have a valid category, but no valid port.
 			# we will display the category only if they did *try* to speciy a port.
 			# i.e. they suuplied an invalid port name
@@ -211,30 +230,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 	if ($Debug) echo 'let us see what we will include now....<br>';
 
-	if ($IsPort) {
-		if ($Debug) echo 'including missing-port<BR>';
-		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-port.php');
-
-		if ($Debug) echo 'including missing-port<BR>';
-
-		if ($HasCommitsOnBranch) {
-			# if zero is returned, all is well, otherwise, we can't display that category/port.
-			if ($Debug) echo 'invoking freshports_PortDisplay<br>';
-			if (freshports_PortDisplay($db, $category, $port, $Branch)) {
-				echo 'freshports_PortDisplay returned non-zero';
-				return -1;
-			}
-		} else {
-			# if zero is returned, all is well, otherwise, we can't display that category/port.
-			if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
-			if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
-				echo 'freshports_PortDisplay returned non-zero';
-				return -1;
-			}
-		}
-	}
-
-	if ($IsCategory && !$IsPort) {
+	if ($IsCategory) {
 		if ($Debug) {
 			echo 'This is a category ***<br>';
 			syslog(LOG_NOTICE, 'invoking ' . $_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -170,27 +170,20 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 			if ($Debug) echo 'including missing-port<BR>';
 
-			if ($HasCommitsOnBranch) {
+			if ($Debug) echo 'invoking freshports_PortDisplay<br>';
+			$result = freshports_PortDisplay($db, $category, $port, $Branch, $HasCommitsOnBranch);
+			if ($result) {
 				# if zero is returned, all is well, otherwise, we can't display that category/port.
-				if ($Debug) echo 'invoking freshports_PortDisplay<br>';
-				if (freshports_PortDisplay($db, $category, $port, $Branch)) {
-					echo 'freshports_PortDisplay returned non-zero';
-					return -1;
+				if ($Debug) {
+					echo "freshports_PortDisplay returned non-zero, had commits on branch: $HasCommitsOnBranch";
 				}
-			} else {
-				# if zero is returned, all is well, otherwise, we can't display that category/port.
-				if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
-				if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
-					echo 'freshports_PortDisplay returned non-zero';
-					return -1;
-				}
+				return $result;
 			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
 			if ($Debug) echo 'This is an element<br>';
 			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
-			freshports_NonPortDescription($db, $ElementRecord);
-			exit;
+			return freshports_NonPortDescription($db, $ElementRecord);
 		}
 	} else {
 		if ($Debug) echo 'not an element<br>';
@@ -253,8 +246,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			syslog(LOG_NOTICE, 'invoking ' . $_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
 		}
 		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
-		freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
-		exit;
+		return freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
 	}
 
 	if ($Debug) echo 'we hit rock bottom in ' . __FUNCTION__ . ' of ' . __FILE__;

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -171,6 +171,10 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
+			if ($Debug) echo 'This is an element<br>';
+			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
+			freshports_NonPortDescription($db, $ElementRecord);
+			exit;
 		}
 	} else {
 		if ($Debug) echo 'not an element<br>';
@@ -237,13 +241,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
 		freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
-		exit;
-	}
-
-	if ($IsElement && !$IsPort) {
-		if ($Debug) echo 'This is an element<br>';
-		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
-		freshports_NonPortDescription($db, $ElementRecord);
 		exit;
 	}
 

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -75,11 +75,12 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	if ($Debug) echo "PATH_NAME='" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
 	# let's see if this is a category.
-	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, 1)) {
+	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, false)) {
 		$IsElement = true;
 		if ($Debug) echo 'we found an element for that<br>';
 		if ($Debug) echo "we have: '$ElementRecord->element_pathname'<br>";
 		if ($Debug) echo " we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
+
 		if (PathnameDiffers($ElementRecord->element_pathname . '/', FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME)) {
 			# in a case insensitive search, we want to redirect if the case was wrong
 			if ($Debug) echo "we are redirecting to '" . $ElementRecord->element_pathname . "/'<br>";
@@ -93,7 +94,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 			header("HTTP/1.1 301 Moved Permanently");
 			header('Location: ' . $protocol . '://' . $_SERVER['HTTP_HOST'] . str_replace(FRESHPORTS_PORTS_TREE_PREFIX, '/', $ElementRecord->element_pathname . '/'));
-			exit;
+			return false;
 		}
 
 		if ($Debug) echo 'checking if this is a Category<br>';

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -2,18 +2,8 @@
 
 function PathnameDiffers($Path1, $Path2) {
     # if the two paths are different, we might want to redirect
-    # if one path ends in a / and the other does not, adjust them
-    if (substr($Path1, -1) == '/') {
-        if (substr($Path2, -1) != '/') {
-	    $Path2 .= '/';
-	}
-    } else {
-        if (substr($Path2, -1) == '/') {
-	    $Path1 .= '/';
-	}
-    }
-
-    return $Path1 != $Path2;
+    # compare the two paths, ignoring any trailing slashes
+    return rtrim($Path1, '/') != rtrim($Path2, '/');
 }
 
 function freshports_Parse404URI($REQUEST_URI, $db) {

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -308,4 +308,5 @@ if ($ShowAds && $BannerAd) {
 
 	<?php
 
+	return false;
 	}

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -217,4 +217,5 @@ function freshports_NonPortDescription($db, $element_record) {
 </html>
 
 <?
+	return false;
 } # end of freshports_NonPortDescription

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -293,9 +293,6 @@ function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommi
 
 	GLOBAL $ShowAds, $BannerAd;
 
-	GLOBAL $ShowAds;
-	GLOBAL $BannerAd;
-
 	if ($ShowAds && $BannerAd) {
 		$HTML_For_Ad = "<hr><center>\n" . Ad_728x90PortDescription() . "\n</center>\n<hr>\n";
 	} else{

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -78,20 +78,7 @@ function DisplayPortCommits($port, $PageNumber) {
 	return $HTML;
 }
 
-function freshports_PortDisplay($db, $category, $port, $branch) {
-	return _freshports_PortDisplayHelper($db, $category, $port, $branch);
-}
-
-function freshports_PortDisplayNotOnBranch($db, $category, $port, $branch) {
-	return _freshports_PortDisplayHelper($db, $category, $port, $branch, false);
-}
-
-function _freshPorts_GetPortDisplay() {
-
-}
-
-function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
-	GLOBAL $FreshPortsTitle;
+function freshports_PortDisplay($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
 	GLOBAL $User;
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/port-display.php');
@@ -498,6 +485,5 @@ document.body.appendChild(sheet);
 
 <?php
 
-return 0;
-
+return false;
 }

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -18,14 +18,14 @@
 
 <?php echo freshports_MainTable(); ?>
 <TR>
-<TD WIDTH="100%" VALIGN="top">
+<TD class="content">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <td class="accent"><BIG>
+    <td class="accent"><span>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>
-</BIG></td>
+</span></td>
 </TR>
 
 <TR>

--- a/www/--/index.php
+++ b/www/--/index.php
@@ -143,7 +143,7 @@ echo 'done';
         break;
 
     default:
-        $result = freshports_Parse404URI($_SERVER['REQUEST_URI'], $db);
+        $not_found = freshports_Parse404URI($_SERVER['REQUEST_URI'], $db);
 
         # if you get here, we could not find anything in the database, so let's run 
         # the 404 code.
@@ -151,7 +151,7 @@ echo 'done';
         # XXX move missing.php out of DOCUMENT_ROOT
         #echo "\$result='$result'";
 
-        if ($result != '') {
-	    require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing.php');
+        if ($not_found) {
+            require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing.php');
         }
 }


### PR DESCRIPTION
Bit of a refactor of the logic used to route 404 URIs to detect the page to take the user to.

- Mostly consolidating branches so there's a bit less state to keep track of; the only big state now is for categories; ports and other elements are handled as they are encountered
- Removal of some redundant wrapping functions
- I think this fixes some issues with the existing implementation:
  - 301s to fix case sensitivity issues previously didn't work because the check only happened after succeeding on a case sensitive search; so it would always match (so e.g. https://www.freshports.org/www/DENO/ is "missing", rather than redirecting ala https://a.freshports.org/www/DENO/ ) (I'm not familiar enough with the prepared statements used here to know if the case-insensitive search will have much of a negative performance impact)
  - If a branch was specified and commits for that port+branch weren't found, instead of trying again checking "head", it would just try checking the same branch but without case sensitivity
- Also a bit of HTML cleanup on the 404/missing page
- A tiny bit of general cleanup