### PR TITLE
HTML Cleanup: Port pages

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1264,7 +1264,11 @@ class port_display {
 	}
 
 	function ReplaceAdvertismentToken($HTML, $Ad) {
-		$HTML = str_replace(port_display_AD, $Ad, $HTML);
+		if ($Ad) {
+			$HTML = str_replace(port_display_AD, $Ad, $HTML);
+		} else {
+			$HTML = str_replace('<dt>' . port_display_AD . '</dt>', '', $HTML);
+		}
 
 		return $HTML;
 	}

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1280,7 +1280,7 @@ class port_display {
 			if ( $NumRows > 0 ) {
 				# everything "required for" XXX goes under this section.
 				# Each one of Build, Extract, etc, gets this.
-				$HTML .= '<dd class="required">for ' . $title . "\n";
+				$HTML .= '<dd class="required"><dl><dt>for ' . $title . "</dt>\n";
 
 				# Let's fetch the first port, and see if it's deleted.  If it is, we don't need this first loop
 				$PortDependencies->FetchNth(0);
@@ -1288,8 +1288,7 @@ class port_display {
 					#
 					# START OF LIST for this type of Required 
 					#
-					$div = '<dl>
-					        <dd id="RequiredBy' . $title . '">
+					$div = '<dd id="RequiredBy' . $title . '">
 					            <ol class="depends" id="requiredfor' . $title . '" style="margin-bottom: 0px">' . "\n";
 
 					$firstDeletedPort = -1;     # we might be able to combine this with deletedPortFound

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1074,10 +1074,10 @@ class port_display {
 
 						# If showing a - for the version, center align it
 						$title = $this->packageToolTipText($package_line['last_checked_latest'], $package_line['repo_date_latest'], $package_line['processed_date_latest']);
-						$HTML .= '<td class="version" ' . ($package_version_latest    == '-' ? ' align ="center"' : '') . ' title="' . $title . '">' . $package_version_latest    . '</td>';
+						$HTML .= '<td class="version ' . ($package_version_latest    == '-' ? 'noversion' : '') . '" title="' . $title . '">' . $package_version_latest    . '</td>';
 
 						$title = $this->packageToolTipText($package_line['last_checked_quarterly'], $package_line['repo_date_quarterly'], $package_line['processed_date_quarterly']);
-						$HTML .= '<td class="version" ' . ($package_version_quarterly == '-' ? ' align ="center"' : '') . ' title="' . $title . '">' . $package_version_quarterly . '</td>';
+						$HTML .= '<td class="version ' . ($package_version_quarterly == '-' ? 'noversion' : '') . '" title="' . $title . '">' . $package_version_quarterly . '</td>';
 						$HTML .= '</tr>';
 					}
 					$HTML .= '</table>&nbsp;';

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1426,11 +1426,11 @@ function freshports_PortCommitPrint($commit, $category, $port, $VuXMLList) {
 	}
 
 	$HTML .= "</td>\n";
-	$HTML .= '    <td valign="top">';
+	$HTML .= '    <td class="commit-details">';
 	$HTML .= freshports_CommitterEmailLink($commit->committer) . '&nbsp;' . freshports_Search_Committer($commit->committer);;
 
 	$HTML .= "</td>\n";
-	$HTML .= '    <td valign="top" width="*">';
+	$HTML .= '    <td class="commit-details">';
 
 	$HTML .= freshports_CommitDescriptionPrint($commit->description, $commit->encoding_losses, $freshports_CommitMsgMaxNumOfLinesToShow, freshports_MoreCommitMsgToShow($commit->message_id, $freshports_CommitMsgMaxNumOfLinesToShow));
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1176,6 +1176,45 @@ function FormatTime($Time, $Adjustment, $Format) {
 	return date($Format, strtotime($Time) + $Adjustment);
 }
 
+function freshports_UpdatingOutput($NumRowsUpdating, $PortsUpdating, $port) {
+	$HTML = '';
+	
+	if ($NumRowsUpdating > 0) {
+		$HTML .= '<TABLE class="ports-updating fullwidth bordered">' . "\n";
+		$HTML .= "<TR>\n";
+		$HTML .= freshports_PageBannerText('<a id="updating">Notes from UPDATING</a>');
+		$HTML .= "<tr><td><dl>\n";
+		$HTML .= "<dt>These upgrade notes are taken from <a href=\"/UPDATING\">/usr/ports/UPDATING</a></dt>";
+		$HTML .= "<dd><ul>\n";
+
+		$Hiding = false;
+		for ($i = 0; $i < $NumRowsUpdating; $i++) {
+			$PortsUpdating->FetchNth($i);
+			if ($i == 1) {
+				$Hiding = true;
+				# end the old list, start a new list
+				$HTML .= "</ul></dd>\n";
+				$HTML .= '<dt><a href="#" id="UPDATING-Extra-show" class="showLink" onclick="showHide(\'UPDATING-Extra\');return false;">Expand this list (' . ($NumRowsUpdating - 1) . ' items)</a></dt>';
+				$HTML .= '<dd id="UPDATING-Extra" class="more UPDATING">';
+
+				# start the new list of all hidden items
+				$HTML .= "<ul>\n";
+			}
+
+			$HTML .= '<li>' . freshports_PortsUpdating($port, $PortsUpdating) . "</li>\n";
+		}
+		if ($Hiding) {
+			$HTML .= '<li class="nostyle"><a href="#" id="UPDATING-Extra-hide2" class="hideLink" onclick="showHide(\'UPDATING-Extra\');return false;">Collapse this list.</a></li>';
+		}
+
+		$HTML .= "</ul></dd>";
+		$HTML .= "</dl></td></tr>\n";
+		$HTML .= "</table>\n";
+	}
+
+	return $HTML;
+}
+
 function freshports_PortCommitsHeader($port) {
 	# print the header for the commits for a port
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1183,7 +1183,7 @@ function freshports_PortCommitsHeader($port) {
 	
 	$HTML = '';
 
-	$HTML .= '<table class="fullwidth bordered" cellpadding="5">' . "\n";
+	$HTML .= '<table class="commit-list fullwidth bordered">' . "\n";
 	$HTML .= "<tr>\n";
 
 	$Columns = 3;
@@ -1198,7 +1198,7 @@ function freshports_PortCommitsHeader($port) {
 		$HTML .= '</td></tr>';
 	}
 
-	$HTML .= '<tr><td width="180"><b>Date</b></td><td><b>By</b></td><td><b>Description</b></td>';
+	$HTML .= '<tr><th>Date</th><th>By</th><th>Description</th>';
 
 	$HTML .= "</tr>\n";
 

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1326,13 +1326,13 @@ function freshports_PortCommits($port, $PageNumber = 1, $NumCommitsPerPage = 100
 	$NumCommitsHTML .= '</p>';
 
 	if ($PageLinks != '') {
-		$PageLinksHTML = '<p align="center">' . $PageLinks . '</p>';
+		$PageLinksHTML = '<p class="pagination">' . $PageLinks . '</p>';
 	} else {
 		$PageLinksHTML = '';
 	}
 
 	# this is the 1st of 2 places where NumCommitsHTML is used.
-	$HTML .= '<p align="left"><a id="history"></a>' . $NumCommitsHTML . $PageLinksHTML;
+	$HTML .= '<p id="history">' . $NumCommitsHTML . $PageLinksHTML;
 
 	if ($Commits->Debug) echo "PageNumber='$PageNumber'<br>Offset='$Offset'<br>";
 	
@@ -1360,7 +1360,7 @@ function freshports_PortCommits($port, $PageNumber = 1, $NumCommitsPerPage = 100
 	
 	# this is the 2nd of 2 places where NumCommitsHTML is used.
 	# no id=history here
-	$HTML .= '<p align="left">' . $NumCommitsHTML . $PageLinksHTML;
+	$HTML .= '<p>' . $NumCommitsHTML . $PageLinksHTML;
 
 	return $HTML;
 }

--- a/include/watch-lists.php
+++ b/include/watch-lists.php
@@ -115,46 +115,6 @@ function freshports_WatchListCountDefault($db, $UserID) {
 	return $myrow["count"];
 }
 
-# XXX I have no idea why UPDATING is in watch-lists.php
-function freshports_UpdatingOutput($NumRowsUpdating, $PortsUpdating, $port) {
-	$HTML = '';
-	
-	if ($NumRowsUpdating > 0) {
-		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
-		$HTML .= "<TR>\n";
-		$HTML .= freshports_PageBannerText('<a id="updating">Notes from UPDATING</a>');
-		$HTML .= "<tr><td><dl>\n";
-		$HTML .= "<dt>These upgrade notes are taken from <a href=\"/UPDATING\">/usr/ports/UPDATING</a></dt>";
-		$HTML .= "<dd><ul>\n";
-
-		$Hiding = false;
-		for ($i = 0; $i < $NumRowsUpdating; $i++) {
-			$PortsUpdating->FetchNth($i);
-			if ($i == 1) {
-				$Hiding = true;
-				# end the old list, start a new list
-				$HTML .= "</ul></dd>\n";
-				$HTML .= '<dt><a href="#" id="UPDATING-Extra-show" class="showLink" onclick="showHide(\'UPDATING-Extra\');return false;">Expand this list (' . ($NumRowsUpdating - 1) . ' items)</a></dt>';
-				$HTML .= '<dd id="UPDATING-Extra" class="more UPDATING">';
-
-				# start the new list of all hidden items
-				$HTML .= "<ul>\n";
-			}
-
-			$HTML .= '<li>' . freshports_PortsUpdating($port, $PortsUpdating) . "</li>\n";
-		}
-		if ($Hiding) {
-			$HTML .= '<li class="nostyle"><a href="#" id="UPDATING-Extra-hide2" class="hideLink" onclick="showHide(\'UPDATING-Extra\');return false;">Collapse this list.</a></li>';
-		}
-
-		$HTML .= "</ul></dd>";
-		$HTML .= "</dl></td></tr>\n";
-		$HTML .= "</table>\n";
-	}
-
-	return $HTML;
-}
-
 function freshports_WatchListVerifyToken($db, $token) {
 	$id = '';
 

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -35,7 +35,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	$Debug  = 0;
 	$result = false;
 
-	$IsPort     = false;
 	$IsCategory = false;
 	$IsElement  = false;
 	$HasCommitsOnBranch = false;
@@ -94,12 +93,12 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	define('PATH_NAME', $pathname);
 	if ($Debug) echo "PATH_NAME='" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
-	# let's see if this is a category.
+	# let's see if this exists on the target branch
 	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, false)) {
 		$IsElement = true;
 		if ($Debug) echo 'we found an element for that<br>';
 		if ($Debug) echo "we have: '$ElementRecord->element_pathname'<br>";
-		if ($Debug) echo " we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
+		if ($Debug) echo "we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
 		# in a case insensitive search, we want to redirect if the case was wrong
 		if (PathnameDiffers($ElementRecord->element_pathname, FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME)) {
@@ -118,9 +117,9 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo 'we found an element for that, therefore, there must be commits!<br>';
 			$HasCommitsOnBranch = true; // this is true even if the branch is head
 		}
+	# okay, let's try on head...
 	} else if ($Branch != BRANCH_HEAD) {	
 		if ($Debug) echo 'trying on head next<br>';
-		# if this is not a category, let's check for details on what might be a port
 		if ($Debug) echo 'checking ' . FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME . ' to see what we find<br>';
 		if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME, false)) {
 			# again, we want to fix the case if it's wrong
@@ -132,7 +131,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			}
 			$IsElement          = true;
 			$HasCommitsOnBranch = false; // we had to fall back to head to find this element
-			$IsCategory = $ElementRecord->IsCategory();
+			$IsCategory         = $ElementRecord->IsCategory();
 		}
 	} else {
 		if ($Debug) echo 'we found no element for that.<br>';
@@ -157,8 +156,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 
 		if ($ElementRecord->IsPort()) {
-			$IsPort = true;
-
 			# we don't use list($category, $port) so we don't have to worry
 			# about extra bits
 			$PathParts = explode('/', PATH_NAME);
@@ -227,16 +224,13 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "Port is '$port'<br>";
 		}
 
-		if (IsSet($port)) {
-			$result = $REQUEST_URI;
-			if ($Debug) echo 'This is a Port but there is no element for it.<br>';
-		}
+		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';}
 
 		if (IsSet($category)) {
 			# we have a valid category, but no valid port.
-			# we will display the category only if they did *try* to speciy a port.
-			# i.e. they suuplied an invalid port name
-			if ($Debug) echo 'This is a category &&&<br>';
+			# we will display the category only if they did *try* to specify a port.
+			# i.e. they supplied an invalid port name
+			if ($Debug) echo 'This is a category <br>';
 
 			if (IsSet($port)) {
 				if ($Debug)  'Invalid port supplied for a valid category<br>';

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -118,7 +118,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			$HasCommitsOnBranch = true; // this is true even if the branch is head
 		}
 	# okay, let's try on head...
-	} else if ($Branch != BRANCH_HEAD) {	
+	} else if ($Branch != BRANCH_HEAD) {
 		if ($Debug) echo 'trying on head next<br>';
 		if ($Debug) echo 'checking ' . FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME . ' to see what we find<br>';
 		if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_HEAD_PREFIX . PATH_NAME, false)) {
@@ -217,7 +217,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "Port is '$port'<br>";
 		}
 
-		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';}
+		if (IsSet($port) && $Debug) echo 'This is a Port but there is no element for it.<br>';
 
 		if (IsSet($category)) {
 			# we have a valid category, but no valid port.

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -7,7 +7,6 @@ function PathnameDiffers($Path1, $Path2) {
 }
 
 function freshports_Parse404URI($REQUEST_URI, $db) {
-	#
 	# we have a pending 404
 	# if we can parse it, then do so and return a false value;
 	# otherwise, return a non-false value.
@@ -15,20 +14,19 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	GLOBAL $User;
 
 	$Debug  = 0;
-	$result = '';
+	$result = false;
 
 	$IsPort     = false;
 	$IsCategory = false;
 	$IsElement  = false;
 	$HasCommitsOnBranch = false;
+	$CategoryID = 0;
 
 	if ($Debug) {
 		echo "Debug is turned on.  Only 404 will be returned now because we cannot alter the headers at this time.<br>\n";
 		echo "\$REQUEST_URI='$REQUEST_URI'<br>";
 		phpinfo();
 	}
-
-	$CategoryID = 0;
 
 	$URLParts = parse_url($_SERVER['REQUEST_URI']);
 	if ($Debug)

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -148,6 +148,27 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			if ($Debug) echo "This is a port!<br>";
 			if ($Debug) echo "Category='$category'<br>";
 			if ($Debug) echo "Port='$port'<br>";
+
+			if ($Debug) echo 'including missing-port<BR>';
+			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-port.php');
+
+			if ($Debug) echo 'including missing-port<BR>';
+
+			if ($HasCommitsOnBranch) {
+				# if zero is returned, all is well, otherwise, we can't display that category/port.
+				if ($Debug) echo 'invoking freshports_PortDisplay<br>';
+				if (freshports_PortDisplay($db, $category, $port, $Branch)) {
+					echo 'freshports_PortDisplay returned non-zero';
+					return -1;
+				}
+			} else {
+				# if zero is returned, all is well, otherwise, we can't display that category/port.
+				if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
+				if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
+					echo 'freshports_PortDisplay returned non-zero';
+					return -1;
+				}
+			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
 		}
@@ -184,13 +205,11 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 
 		if (IsSet($port)) {
-			$IsPort = false;
 			$result = $REQUEST_URI;
-
 			if ($Debug) echo 'This is a Port but there is no element for it.<br>';
 		}
 
-		if (IsSet($category) && !$IsPort) {
+		if (IsSet($category)) {
 			# we have a valid category, but no valid port.
 			# we will display the category only if they did *try* to speciy a port.
 			# i.e. they suuplied an invalid port name
@@ -211,30 +230,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 	if ($Debug) echo 'let us see what we will include now....<br>';
 
-	if ($IsPort) {
-		if ($Debug) echo 'including missing-port<BR>';
-		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-port.php');
-
-		if ($Debug) echo 'including missing-port<BR>';
-
-		if ($HasCommitsOnBranch) {
-			# if zero is returned, all is well, otherwise, we can't display that category/port.
-			if ($Debug) echo 'invoking freshports_PortDisplay<br>';
-			if (freshports_PortDisplay($db, $category, $port, $Branch)) {
-				echo 'freshports_PortDisplay returned non-zero';
-				return -1;
-			}
-		} else {
-			# if zero is returned, all is well, otherwise, we can't display that category/port.
-			if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
-			if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
-				echo 'freshports_PortDisplay returned non-zero';
-				return -1;
-			}
-		}
-	}
-
-	if ($IsCategory && !$IsPort) {
+	if ($IsCategory) {
 		if ($Debug) {
 			echo 'This is a category ***<br>';
 			syslog(LOG_NOTICE, 'invoking ' . $_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -170,27 +170,20 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 			if ($Debug) echo 'including missing-port<BR>';
 
-			if ($HasCommitsOnBranch) {
+			if ($Debug) echo 'invoking freshports_PortDisplay<br>';
+			$result = freshports_PortDisplay($db, $category, $port, $Branch, $HasCommitsOnBranch);
+			if ($result) {
 				# if zero is returned, all is well, otherwise, we can't display that category/port.
-				if ($Debug) echo 'invoking freshports_PortDisplay<br>';
-				if (freshports_PortDisplay($db, $category, $port, $Branch)) {
-					echo 'freshports_PortDisplay returned non-zero';
-					return -1;
+				if ($Debug) {
+					echo "freshports_PortDisplay returned non-zero, had commits on branch: $HasCommitsOnBranch";
 				}
-			} else {
-				# if zero is returned, all is well, otherwise, we can't display that category/port.
-				if ($Debug) echo 'invoking freshports_PortDisplayNotOnBranch<br>';
-				if (freshports_PortDisplayNotOnBranch($db, $category, $port, $Branch)) {
-					echo 'freshports_PortDisplay returned non-zero';
-					return -1;
-				}
+				return $result;
 			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
 			if ($Debug) echo 'This is an element<br>';
 			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
-			freshports_NonPortDescription($db, $ElementRecord);
-			exit;
+			return freshports_NonPortDescription($db, $ElementRecord);
 		}
 	} else {
 		if ($Debug) echo 'not an element<br>';
@@ -253,8 +246,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			syslog(LOG_NOTICE, 'invoking ' . $_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
 		}
 		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
-		freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
-		exit;
+		return freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
 	}
 
 	if ($Debug) echo 'we hit rock bottom in ' . __FUNCTION__ . ' of ' . __FILE__;

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -171,6 +171,10 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			}
 		} else {
 			if ($Debug) echo 'The call to ElementRecord indicates this is not a port<br>';
+			if ($Debug) echo 'This is an element<br>';
+			require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
+			freshports_NonPortDescription($db, $ElementRecord);
+			exit;
 		}
 	} else {
 		if ($Debug) echo 'not an element<br>';
@@ -237,13 +241,6 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 		}
 		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-category.php');
 		freshports_CategoryByID($db, $CategoryID, $page, $User->page_size, $Branch);
-		exit;
-	}
-
-	if ($IsElement && !$IsPort) {
-		if ($Debug) echo 'This is an element<br>';
-		require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing-non-port.php');
-		freshports_NonPortDescription($db, $ElementRecord);
 		exit;
 	}
 

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -75,11 +75,12 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 	if ($Debug) echo "PATH_NAME='" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
 
 	# let's see if this is a category.
-	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, 1)) {
+	if ($ElementRecord->FetchByName(FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME, false)) {
 		$IsElement = true;
 		if ($Debug) echo 'we found an element for that<br>';
 		if ($Debug) echo "we have: '$ElementRecord->element_pathname'<br>";
 		if ($Debug) echo " we had: '" . FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME . "'<br>";
+
 		if (PathnameDiffers($ElementRecord->element_pathname . '/', FRESHPORTS_PORTS_TREE_PREFIX . PATH_NAME)) {
 			# in a case insensitive search, we want to redirect if the case was wrong
 			if ($Debug) echo "we are redirecting to '" . $ElementRecord->element_pathname . "/'<br>";
@@ -93,7 +94,7 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 
 			header("HTTP/1.1 301 Moved Permanently");
 			header('Location: ' . $protocol . '://' . $_SERVER['HTTP_HOST'] . str_replace(FRESHPORTS_PORTS_TREE_PREFIX, '/', $ElementRecord->element_pathname . '/'));
-			exit;
+			return false;
 		}
 
 		if ($Debug) echo 'checking if this is a Category<br>';

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -2,18 +2,8 @@
 
 function PathnameDiffers($Path1, $Path2) {
     # if the two paths are different, we might want to redirect
-    # if one path ends in a / and the other does not, adjust them
-    if (substr($Path1, -1) == '/') {
-        if (substr($Path2, -1) != '/') {
-	    $Path2 .= '/';
-	}
-    } else {
-        if (substr($Path2, -1) == '/') {
-	    $Path1 .= '/';
-	}
-    }
-
-    return $Path1 != $Path2;
+    # compare the two paths, ignoring any trailing slashes
+    return rtrim($Path1, '/') != rtrim($Path2, '/');
 }
 
 function freshports_Parse404URI($REQUEST_URI, $db) {

--- a/rewrite/missing-category.php
+++ b/rewrite/missing-category.php
@@ -308,4 +308,5 @@ if ($ShowAds && $BannerAd) {
 
 	<?php
 
+	return false;
 	}

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -217,4 +217,5 @@ function freshports_NonPortDescription($db, $element_record) {
 </html>
 
 <?
+	return false;
 } # end of freshports_NonPortDescription

--- a/rewrite/missing-non-port.php
+++ b/rewrite/missing-non-port.php
@@ -150,7 +150,7 @@ function freshports_NonPortDescription($db, $element_record) {
 	
 	$links = $Pager->GetLinks();
 
-	$NumCommitsHTML = '<tr><td><p align="left">Number of commits found: ' . $NumCommits;
+	$NumCommitsHTML = '<tr><td><p>Number of commits found: ' . $NumCommits;
 
 	$Offset = 0;
 	$PageLinks = $links['all'];
@@ -170,7 +170,7 @@ function freshports_NonPortDescription($db, $element_record) {
 
 	$NumCommitsHTML .= '</p>';
 	if ($PageLinksHTML != '') {
-		$PageLinksHTML = '<p align="center">' . $PageLinksHTML . '</p>';
+		$PageLinksHTML = '<p class="pagination">' . $PageLinksHTML . '</p>';
 	}
 
 	$NumCommitsHTML .= $PageLinksHTML . '</td></tr>';

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -38,7 +38,7 @@ function DisplayPortCommits($port, $PageNumber) {
 	$NumRowsTo      = $PortsMovedTo->FetchInitialiseTo($port->id);
 
 	if ($NumRowsFrom + $NumRowsTo > 0) {
-		$HTML .= '<TABLE class="fullwidth bordered" CELLPADDING="5">' . "\n";
+		$HTML .= '<TABLE class="ports-moved fullwidth bordered">' . "\n";
 		$HTML .= "<TR>\n";
 		$HTML .= freshports_PageBannerText("Port Moves");
 		$HTML .= "<tr><td>\n";

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -293,9 +293,6 @@ function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommi
 
 	GLOBAL $ShowAds, $BannerAd;
 
-	GLOBAL $ShowAds;
-	GLOBAL $BannerAd;
-
 	if ($ShowAds && $BannerAd) {
 		$HTML_For_Ad = "<hr><center>\n" . Ad_728x90PortDescription() . "\n</center>\n<hr>\n";
 	} else{

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -95,9 +95,9 @@ function freshports_PortDisplay($db, $category, $port, $branch, $HasCommitsOnBra
 	if (IsSet($_SERVER['REQUEST_URI'])) {
 		$url_query = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
 		parse_str($url_query, $url_args);
-        } else {
-           $url_args = null;
-        }
+	} else {
+		$url_args = null;
+	}
 
 	if ($Debug) {
 	  echo 'query parts';

--- a/rewrite/missing-port.php
+++ b/rewrite/missing-port.php
@@ -78,20 +78,7 @@ function DisplayPortCommits($port, $PageNumber) {
 	return $HTML;
 }
 
-function freshports_PortDisplay($db, $category, $port, $branch) {
-	return _freshports_PortDisplayHelper($db, $category, $port, $branch);
-}
-
-function freshports_PortDisplayNotOnBranch($db, $category, $port, $branch) {
-	return _freshports_PortDisplayHelper($db, $category, $port, $branch, false);
-}
-
-function _freshPorts_GetPortDisplay() {
-
-}
-
-function _freshports_PortDisplayHelper($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
-	GLOBAL $FreshPortsTitle;
+function freshports_PortDisplay($db, $category, $port, $branch, $HasCommitsOnBranch = true) {
 	GLOBAL $User;
 
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/port-display.php');
@@ -498,6 +485,5 @@ document.body.appendChild(sheet);
 
 <?php
 
-return 0;
-
+return false;
 }

--- a/rewrite/missing.php
+++ b/rewrite/missing.php
@@ -18,14 +18,14 @@
 
 <?php echo freshports_MainTable(); ?>
 <TR>
-<TD WIDTH="100%" VALIGN="top">
+<TD class="content">
 <?php echo freshports_MainContentTable(); ?>
 <TR>
-    <td class="accent"><BIG>
+    <td class="accent"><span>
 <?
    echo "$FreshPortsTitle -- $Title";
 ?>
-</BIG></td>
+</span></td>
 </TR>
 
 <TR>

--- a/www/--/index.php
+++ b/www/--/index.php
@@ -143,7 +143,7 @@ echo 'done';
         break;
 
     default:
-        $result = freshports_Parse404URI($_SERVER['REQUEST_URI'], $db);
+        $not_found = freshports_Parse404URI($_SERVER['REQUEST_URI'], $db);
 
         # if you get here, we could not find anything in the database, so let's run 
         # the 404 code.
@@ -151,7 +151,7 @@ echo 'done';
         # XXX move missing.php out of DOCUMENT_ROOT
         #echo "\$result='$result'";
 
-        if ($result != '') {
-	    require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing.php');
+        if ($not_found) {
+            require_once($_SERVER['DOCUMENT_ROOT'] . '/../rewrite/missing.php');
         }
 }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -73,6 +73,18 @@ td.content {
   margin: 1px;
 }
 
+.commit-list th {
+  text-align: left;
+}
+
+.commit-list td, .commit-list th {
+  padding: 5px;
+}
+
+.commit-list td:first-child, .commit-list th:first-child {
+  width: 180px;
+}
+
 .commit-details {
   vertical-align: top;
   white-space: nowrap;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -396,6 +396,10 @@ td.version:hover {
   background-color: #777;
 }
 
+.packages .version.noversion {
+  text-align: center;
+}
+
 
 /*
   from https://www.w3schools.com/css/css_tooltip.asp

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -77,7 +77,9 @@ td.content {
   text-align: left;
 }
 
-.commit-list td, .commit-list th {
+.commit-list td, .commit-list th,
+.ports-moved td, .ports-moved th,
+.ports-updating td, .ports-updating th {
   padding: 5px;
 }
 


### PR DESCRIPTION
Follows from #277 

Cleans up deprecated HTML attributes/elements in use on port pages (e.g. https://www.freshports.org/devel/py-buildbot/)

Mostly align, valign, width attributes and some of the b elements.

Still a handful of public pages that need more work to be valid HTML5, but we're getting there. More PRs to come, then there'll be one to switch the doctype and resync the styles with non-quirks stylesheets.

Please let me know if there are any issues!