### PR TITLE
HTML Cleanup: public pages

### DIFF
--- a/classes/files-display.php
+++ b/classes/files-display.php
@@ -42,7 +42,7 @@ class FilesDisplay {
 		}
 
 		$this->HTML .= '
-<table class="fullwidth bordered" CELLPADDING="5">
+<table class="files-list fullwidth bordered">
 <TR>
 ';
 		switch ($NumRows) {
@@ -64,7 +64,7 @@ class FilesDisplay {
 
 		$this->HTML .= "
 		<TR>
-			<TD><b>Action</b></TD><TD><B>Revision</B></TD><td><b>Annotate/etc</b></td><TD><b>File</b></TD>
+			<th>Action</th><th>Revision</th><th>Annotate/etc</th><th>File</th>
 		</TR>\n";
 
 		for ($i = 0; $i < $NumRows; $i++) {
@@ -99,7 +99,7 @@ class FilesDisplay {
 			$this->HTML .= '  <TD>' . $myrow["revision_name"];
             $this->HTML .= "</TD>";
             
-            $this->HTML .= '<td valign="middle">';
+            $this->HTML .= '<td>';
 #           switch($WhichRepo)
             switch($myrow['repository'])
             {
@@ -158,7 +158,7 @@ class FilesDisplay {
             }
 
             $this->HTML .= '</td>';
-            $this->HTML .= '  <TD WIDTH="100%" VALIGN="middle">';
+            $this->HTML .= '  <TD>';
             
 #           switch($WhichRepo)
             switch($myrow['repository'])

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -238,7 +238,7 @@ class port_display {
           if (!empty($link)) {
             $link = '<a href="' . $link . '">' . $link_title . '</a>';
           } else {
-            $link = '<strike>SVNWeb</strike>';
+            $link = '<del>SVNWeb</del>';
           }
 
           return $link;
@@ -301,7 +301,7 @@ class port_display {
           if (!empty($link)) {
             $link = '<a href="' . $link . '">' . $link_title . '</a>';
           } else {
-            $link = '<strike>git</strike>';
+            $link = '<del>git</del>';
           }
 
           # echo 'returning ' . $link . '<br>';

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1379,17 +1379,17 @@ class port_display {
 		}
 
 		if ( $HTML === '' ) {
-			$HTML .= '<dt>There are no ports dependent upon this port</dt>';
+			$HTML .= '<dd>There are no ports dependent upon this port</dd>';
 		} else {
 			$HTML = '<dt class="required">This port is required by:</dt>' . $HTML;
 			if ($deletedPortFound) {
 				# add some stuff to the front of what we have
 				if ( $port->IsDeleted() ) {
-					$HTML = '<dt>NOTE: dependencies for deleted ports are notoriously suspect</dt>' . $HTML;
+					$HTML = '<dd>NOTE: dependencies for deleted ports are notoriously suspect</dd>' . $HTML;
 				}
 
 				# and to the end...
-				$HTML .= '<dt>* - deleted ports are only shown under the <em>This port is required by</em> section.  It was harder to do for the <em>Required</em> section.  Perhaps later...</dt>';
+				$HTML .= '<dd>* - deleted ports are only shown under the <em>This port is required by</em> section.  It was harder to do for the <em>Required</em> section.  Perhaps later...</dd>';
 			}
 		}
 

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1133,37 +1133,37 @@ class port_display {
 			}
 
 			if ($port->depends_build) {
-				$HTML .= '<dt class="required"><a id="requiredbuild">Build dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredtobuild">';
+				$HTML .= '<dt class="required" id="requiredbuild">Build dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredtobuild">';
 				$HTML .= freshports_depends_links($this->db, $port->depends_build, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
 
 			if ($port->depends_run) {
-				$HTML .= '<dt class="required"><a id="requiredrun">Runtime dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredtorun">';
+				$HTML .= '<dt class="required" id="requiredrun">Runtime dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredtorun">';
 				$HTML .= freshports_depends_links($this->db, $port->depends_run, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
 
 			if ($port->depends_lib) {
-				$HTML .= '<dt class="required"><a id="requiredlib">Library dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredlibraries">';
+				$HTML .= '<dt class="required" id="requiredlib">Library dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredlibraries">';
 				$HTML .= freshports_depends_links($this->db, $port->depends_lib, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
 
 			if ($port->fetch_depends) {
-				$HTML .= '<dt class="required"><a id="requiredfetch">Fetch dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredfetches">';
+				$HTML .= '<dt class="required" id="requiredfetch">Fetch dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredfetches">';
 				$HTML .= freshports_depends_links($this->db, $port->fetch_depends, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
 
 			if ($port->patch_depends) {
-				$HTML .= '<dt class="required"><a id="requiredpatch">Patch dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredpatches">';
+				$HTML .= '<dt class="required" id="requiredpatch">Patch dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredpatches">';
 				$HTML .= freshports_depends_links($this->db, $port->patch_depends, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
 
 			if ($port->extract_depends) {
-				$HTML .= '<dt class="required"><a id="requiredextract">Extract dependencies:</a></dt><dd>' . "\n" . '<ol class="required" id="requiredextracts">';
+				$HTML .= '<dt class="required" id="requiredextract">Extract dependencies:</dt><dd>' . "\n" . '<ol class="required" id="requiredextracts">';
 				$HTML .= freshports_depends_links($this->db, $port->extract_depends, $this->Branch);
 				$HTML .= "\n</ol></dd>\n";
 			}
@@ -1336,7 +1336,7 @@ class port_display {
 						$div .= '<li class="nostyle"><a href="#" class="hideLink" onclick="showHide(\'RequiredBy' . $title . 'Extra\');return false;" >Collapse this list.</a></li>';
 					}
 
-					$div .= '</ol></dd></dl>'; # we always close off this list here.
+					$div .= '</ol></dd>'; # we always close off this list here.
 
 				} else {
 					# the first port was deleted. Therefore, they are all deleted.
@@ -1352,9 +1352,9 @@ class port_display {
 					# is it port or ports?
 					$PluralSingularSuffix = ($NumRows - $firstDeletedPort) > 1 ? 's' : '';
 
-						$div .= '<dl><dt id="RequiredBy' . $title . 'Deleted"></dt><dd class="depends" id="requiredfor' . $title . 'Deleted" style="margin-bottom: 0px">' . "\n";
+					$div .= '<dd id="RequiredBy' . $title . 'Deleted" class="depends">' . "\n";
 
-					$div .= '<dd><p><b>Deleted ports which required this port:</b></p>';
+					$div .= '<p><b>Deleted ports which required this port:</b></p>';
 					$div .= '<a href="#" id="RequiredBy' . $title . 'DeletedExtra-show" class="showLink" onclick="showHide(\'RequiredBy' . $title .
 				                'DeletedExtra\');return false;">Expand this list of ' . ($NumRows - $firstDeletedPort) . ' deleted port' . $PluralSingularSuffix . '</a>';
 
@@ -1368,13 +1368,13 @@ class port_display {
 					}
 
 					$div .= '<li class="nostyle"><a href="#" id="RequiredBy' . $title . 'DeletedExtra-hide2" class="hideLink" onclick="showHide(\'RequiredBy' . $title . 'DeletedExtra\');return false;">Collapse this list of deleted ports.</a></li>';
-					$div .= '</ol></dd></dl>';
+					$div .= '</ol></dd>';
 
 				}
 
 				$HTML .= $div;
 
-				$HTML .= '</dd>'; # required class, with text 'for Build' (for example)
+				$HTML .= '</dl></dd>'; # required class, with text 'for Build' (for example)
 			}
 		}
 

--- a/include/ads-burst-media.php
+++ b/include/ads-burst-media.php
@@ -18,13 +18,13 @@ function Ad_PhpPgAdsBase($Zone, $N) {
 
   return 
 '
-<script language=\'JavaScript\' type=\'text/javascript\' src=\'http://ads.unixathome.org/phpPgAds/adx.js\'></script>
-<script language=\'JavaScript\' type=\'text/javascript\'>
+<script type=\'text/javascript\' src=\'http://ads.unixathome.org/phpPgAds/adx.js\'></script>
+<script type=\'text/javascript\'>
 <!--
    if (!document.phpAds_used) document.phpAds_used = \',\';
    phpAds_random = new String (Math.random()); phpAds_random = phpAds_random.substring(2,11);
    
-   document.write ("<" + "script language=\'JavaScript\' type=\'text/javascript\' src=\'");
+   document.write ("<" + "script type=\'text/javascript\' src=\'");
    document.write ("http://ads.unixathome.org/phpPgAds/adjs.php?n=" + phpAds_random);
    document.write ("&amp;what=zone:' . $Zone . '");
    document.write ("&amp;exclude=" + document.phpAds_used);
@@ -39,7 +39,7 @@ function Ad_PhpPgAdsBase($Zone, $N) {
 function Ad_125x125() {
   return '
 <!-- BEGIN RICH-MEDIA Burst CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/v=2.1S/sz=125x125A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
@@ -53,7 +53,7 @@ document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/
 function Ad_468x60() {
   return '
 <!-- BEGIN RICH-MEDIA NETWORK CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 
@@ -69,7 +69,7 @@ document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/
 function Ad_728x90() {
   return '
 <!-- BEGIN RICH-MEDIA NETWORK CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 
@@ -97,7 +97,7 @@ function Ad_728x90PhorumTop() {
 function Ad_120x600() {
   return '
 <!-- BEGIN RICH-MEDIA NETWORK CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
 if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
 document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.1S/sz=120x600A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
@@ -111,7 +111,7 @@ document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/
 function Ad_160x600() {
   return '
   <!-- BEGIN RICH-MEDIA NETWORK CODE -->
-  <script language="JavaScript" type="text/javascript">
+  <script type="text/javascript">
   rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.1S/sz=120x600A|160x600A/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
@@ -126,7 +126,7 @@ function Ad_160x600() {
 function Ad_468x60_Below() {
   return '
   <!-- BEGIN RICH-MEDIA Burst CODE -->
-  <script language="JavaScript" type="text/javascript">
+  <script type="text/javascript">
   rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/v=2.1S/sz=468x60B/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');
@@ -141,7 +141,7 @@ function Ad_468x60_Below() {
 function Ad_300x250() {
   return '
   <!-- BEGIN RICH-MEDIA Burst CODE -->
-  <script language="JavaScript" type="text/javascript">
+  <script type="text/javascript">
   rnum=Math.round(Math.random() * 100000); ts=String.fromCharCode(60);
   if (window.self != window.top) { nf=\'\' } else { nf=\'NF/\' };
   document.write(ts+\'script src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.1S/sz=300x250A/NZ/\'+rnum+\'/\'+nf+\'RETURN-CODE/JS/">\'+ts+\'/script>\');

--- a/include/burstmedia.php
+++ b/include/burstmedia.php
@@ -13,7 +13,7 @@ function BurstMediaAd() {
 return '
 
 <!-- BEGIN RICH-MEDIA BURST! CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000);
 
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.0S/sz=468x60A|728x90A/\'+rnum+\'/NI/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
@@ -34,7 +34,7 @@ function BurstSkyscraperAd() {
 return '
 
 <!-- BEGIN RICH-MEDIA BURST! CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/sk4556a.cgi/v=2.0S/sz=120x600A|160x600A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
@@ -55,7 +55,7 @@ function Burst_125x125() {
 return '
 
 <!-- BEGIN RICH-MEDIA BURST! CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/cb4556a.cgi/v=2.0S/sz=125x125A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
@@ -72,7 +72,7 @@ function Burst_468x60_Below() {
 return '
 
 <!-- BEGIN RICH-MEDIA BURST! CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ba4556a.cgi/v=2.0S/sz=468x60B/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>
@@ -92,7 +92,7 @@ GLOBAL $ShowAds;
 return '
 
 <!-- BEGIN RICH-MEDIA BURST! CODE -->
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 rnum=Math.round(Math.random() * 100000);
 document.write(\'<scr\'+\'ipt src="http://www.burstnet.com/cgi-bin/ads/ad4556a.cgi/v=2.0S/sz=300x250A/\'+rnum+\'/RETURN-CODE/JS/"><\/scr\'+\'ipt>\');
 </script>

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -246,7 +246,7 @@ function freshports_link_text_to_port_single($text, $CategoryName, $PortName, $B
 	// This differs from freshports_link_to_port_single in the link text is not necessarily the port name.
 
 	$HTML = '';
-	$HTML .= $text . ' : <a href="/' . $CategoryName . '/' . freshports_strip_port_suffix($PortName) . '/';
+	$HTML .= htmlentities($text) . ' : <a href="/' . $CategoryName . '/' . freshports_strip_port_suffix($PortName) . '/';
 	if ($BranchName != BRANCH_HEAD) {
 	  $HTML .= '?branch=' . htmlentities($BranchName);
 	}

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -525,7 +525,7 @@ function freshports_Encoding_Errors() {
 }
 
 function freshports_Encoding_Errors_Link() {
-	return '<a href="/' . FAQLINK . '#encodingerrors">' . freshports_Encoding_Errors() . '<a>';
+	return '<a href="/' . FAQLINK . '#encodingerrors">' . freshports_Encoding_Errors() . '</a>';
 }
 
 function freshports_Repology_Icon() {

--- a/include/freshports_page.php
+++ b/include/freshports_page.php
@@ -32,12 +32,6 @@ class freshports_page extends HTML_Page2 {
 		$this->setMetaData('description',      'FreshPorts - new ports, applications');
 		$this->setMetaData('keywords',         'FreeBSD, index, applications, ports');
 
-		$this->setMetaData('Pragma',           'no-cache', TRUE);
-		$this->setMetaData('Cache-Control',    'no-cache', TRUE);
-		$this->setMetaData('Pragma-directive', 'no-cache', TRUE);
-		$this->setMetaData('cache-directive',  'no-cache', TRUE);
-		$this->setMetaData('Expires',          '0',        TRUE);
-
 		$this->setMetaData('robots', 'noarchive');
 		$this->setMetaData('robots', 'noindex');
 

--- a/rewrite/functions.php
+++ b/rewrite/functions.php
@@ -151,11 +151,8 @@ function freshports_Parse404URI($REQUEST_URI, $db) {
 			require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/categories.php');
 			$Category = new Category($db);
 			$CategoryID = $Category->FetchByElementID($ElementRecord->id);
-		} else {
+		} else if ($ElementRecord->IsPort()) {
 			if ($Debug) echo 'That path does not point at a category!<br>';
-		}
-
-		if ($ElementRecord->IsPort()) {
 			# we don't use list($category, $port) so we don't have to worry
 			# about extra bits
 			$PathParts = explode('/', PATH_NAME);

--- a/www/backend/newsfeeds.php
+++ b/www/backend/newsfeeds.php
@@ -19,7 +19,7 @@
 	$page->setTitle('Newsfeeds');
 
 	$page->addBodyContent('
-	</tr><TR><TD valign="top">
+	</tr><TR><TD>
 	We have five newsfeeds:
 	');
 
@@ -38,7 +38,7 @@
 	$HREF = "<A HREF=\"$URL\">$URL</A>";
 	$page->addBodyContent($HREF . '
 	
-	<p>This RSS feed takes the following optional parameters:
+	<p>This RSS feed takes the following optional parameters:</p>
 	<ul>
 	<li><b>flavor=new</b> : show only new ports (ignores <b>branch</b>).</li>
 	<li><b>flavor=broken</b> : show only new ports (ignores <b>branch</b>).</li>
@@ -47,13 +47,13 @@
 	</ul>
 	<p>
 	Sample URLs include:
+	</p>
 	<ol>
 	<li>' . $URL . 'html.php?branch=2018Q4</li>
 	<li>' . $URL . 'html.php?branch=quarterly</li>
 	<li>' . $URL . 'html.php?flavor=broken</li>
 	<li>' . $URL . 'html.php?flavor=new</li>
 	</ol>
-	</p>
 
 	</LI>');
 

--- a/www/commit.php
+++ b/www/commit.php
@@ -181,7 +181,7 @@ if (file_exists("announcement.txt") && filesize("announcement.txt") > 4) {
 	
 		if (!empty($revision) && count($message_id_array)) {
 			// we have multiple messages for that commit
-			echo '<tr><TD VALIGN="top">';
+			echo '<tr><TD class="content">';
 			echo "We have multiple emails for that revision: ";
 			$Commit->FetchNth(0);
 			$clean_revision = htmlentities($Commit->svn_revision);
@@ -253,9 +253,9 @@ ORDER BY port, element_pathname";
 						$RetVal = $DisplayCommit->CreateHTML();
 	
 						$HTML .= $DisplayCommit->HTML;
-						$HTML .= '<tr><TD VALIGN="top"><p>Number of ports [&amp; non-ports] in this commit: ' . $NumFilesTouched . '</p></td></tr>';
+						$HTML .= '<tr><TD><p>Number of ports [&amp; non-ports] in this commit: ' . $NumFilesTouched . '</p></td></tr>';
 					} else {
-						$HTML .=  '<tr><TD VALIGN="top"><P>Sorry, nothing found in the database....</P>' . "\n";
+						$HTML .=  '<tr><TD><P>Sorry, nothing found in the database....</P>' . "\n";
 						$HTML .=  "</TD></tr>";
 						$DoTheSave = false;
 					}

--- a/www/commit.php
+++ b/www/commit.php
@@ -297,7 +297,7 @@ ORDER BY port, element_pathname";
 
 
 				$PortURL = '<a href="/' . $clean['category'] . '/' . $clean['port'] . '/">' . $clean['category'] . '/' . $clean['port'] . '</a>';
-				$HTML .=  '<p>Showing files for just one port: <big><b>' . $PortURL . '</b></big></p>';
+				$HTML .=  '<p>Showing files for just one port: <span class="element-details">' . $PortURL . '</span></p>';
 				$HTML .=  "<p>$ShowAllFilesURL</p>";
 			} # FilesForJustOnePort
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -367,10 +367,6 @@ li.extraspace {
 .packages th { background-color:#000; color:white; }
 .packages td, .packages th { padding:8px; border:1px solid #000; }
 
-.footer {
-  text-align: center;
-}
-
 .footer > tbody > tr > td > table {
   width: 98%;
   margin: 0 auto;
@@ -415,7 +411,7 @@ td.version:hover {
   background-color: #777;
 }
 
-.packages .version.noversion {
+.packages .version.noversion, .footer, .maintenance {
   text-align: center;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -81,6 +81,7 @@ td.content {
 .ports-moved td, .ports-moved th,
 .ports-updating td, .ports-updating th,
 .files-list td, .files-list th,
+.search-options td, .search-options th,
 .textcontent table td, .textcontent table th {
   padding: 5px;
 }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -80,7 +80,8 @@ td.content {
 .commit-list td, .commit-list th,
 .ports-moved td, .ports-moved th,
 .ports-updating td, .ports-updating th,
-.files-list td, .files-list th {
+.files-list td, .files-list th,
+.textcontent table td, .textcontent table th {
   padding: 5px;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -86,6 +86,21 @@ td.content {
   padding: 5px;
 }
 
+.announce-notes {
+  border-spacing: 4px;
+}
+
+.announce-notes td, .announce-notes th {
+  padding: 4px;
+}
+
+.announce-notes th {
+  font-weight: bold;
+  text-align: right;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
 .commit-list td:first-child, .commit-list th:first-child {
   width: 180px;
 }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -412,7 +412,7 @@ td.version:hover {
   background-color: #777;
 }
 
-.packages .version.noversion, .footer, .maintenance {
+.packages .version.noversion, .footer, .maintenance, .fp-banner {
   text-align: center;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -73,18 +73,23 @@ td.content {
   margin: 1px;
 }
 
-.commit-list th {
+.commit-list th, .files-list th {
   text-align: left;
 }
 
 .commit-list td, .commit-list th,
 .ports-moved td, .ports-moved th,
-.ports-updating td, .ports-updating th {
+.ports-updating td, .ports-updating th,
+.files-list td, .files-list th {
   padding: 5px;
 }
 
 .commit-list td:first-child, .commit-list th:first-child {
   width: 180px;
+}
+
+.files-list td:last-child {
+  width: 100%;
 }
 
 .commit-details {

--- a/www/faq.php
+++ b/www/faq.php
@@ -247,6 +247,9 @@ down you must read to find something you didn't already know.</P>
 	<P id="fallout"><?php echo freshports_Fallout_Icon(); ?>
 		Fallout: a link to search the pkg-fallout archives for this port.</P>
 
+	<P id="repology"><?php echo freshports_Repology_Icon(); ?>
+		Repology: a link to search the Repology packaging hub for this port.</P>
+
 	<P id="bugs-find"><?php echo freshports_Bugs_Find_Icon(); ?>
 		Find Bugs: a link to search for open Problem Reports (issues/bugs) for this port.</P>
 

--- a/www/faq.php
+++ b/www/faq.php
@@ -464,7 +464,7 @@ of a link to a page of commits for that day.
 
 Here are a few examples:
 <blockquote>
-<table class="bordered" CELLPADDING="5">
+<table class="bordered">
 <tr>
 <td><b>Description</b></td>
 <td nowrap valign="top"><b>URL</b></td>
@@ -686,7 +686,7 @@ if you can provide a URL that exercises all the options that require testing.
    <P>
 	For those familiar with the FreeBSD ports structure, the following fields indicate their origin:
 
-<table cellpadding="5" class="borderless">
+<table class="borderless">
 <tr><td><b>Field</b></td><td><b>Origin</b></td></tr>
 <tr><td>Port Name</td><td><code class="code">PORTNAME</code></td></tr>
 <tr><td>Package Name</td><td><code class="code">PKGNAME</code></td></tr>

--- a/www/faq.php
+++ b/www/faq.php
@@ -224,7 +224,7 @@ down you must read to find something you didn't already know.</P>
 
 		<P>Here is a banner which you are free to use to link to this site:</P>
 
-		<P ALIGN="center">
+		<P class="fp-banner">
 		<img src="images/freshports-banner.gif" alt="<?php echo "$FreshPortsName -- $FreshPortsSlogan"; ?>" title="<?php echo "$FreshPortsName -- $FreshPortsSlogan"; ?>" width="468" height="60">
 		</P>
 
@@ -467,19 +467,19 @@ Here are a few examples:
 <table class="bordered">
 <tr>
 <td><b>Description</b></td>
-<td nowrap valign="top"><b>URL</b></td>
+<td><b>URL</b></td>
 </tr>
 <tr>
 <td>The last ten ports</td>
-<td nowrap valign="top"><a href="https://<?php echo $ServerName ?>/index.php?num=10">https://<?php echo $ServerName ?>/index.php?<b>num=10</b></a><br></td>
+<td><a href="https://<?php echo $ServerName ?>/index.php?num=10">https://<?php echo $ServerName ?>/index.php?<b>num=10</b></a><br></td>
 </tr>
 <tr>
 <td>Same as above, but show only two days of previous commits</td>
-<td nowrap valign="top"><a href="https://<?php echo $ServerName ?>/index.php?num=10&amp;days=2">https://<?php echo $ServerName ?>/index.php?num=10&amp;<b>days=2</b></a><br></td>
+<td><a href="https://<?php echo $ServerName ?>/index.php?num=10&amp;days=2">https://<?php echo $ServerName ?>/index.php?num=10&amp;<b>days=2</b></a><br></td>
 </tr>
 <tr>
 <td>Same as above, but show summaries instead of a link to another page</td>
-<td nowrap valign="top"><a href="https://<?php echo $ServerName ?>/index.php?num=10&amp;dailysummary=2">https://<?php echo $ServerName ?>/index.php?num=10&amp;<b>dailysummary=2</b></a></td>
+<td><a href="https://<?php echo $ServerName ?>/index.php?num=10&amp;dailysummary=2">https://<?php echo $ServerName ?>/index.php?num=10&amp;<b>dailysummary=2</b></a></td>
 </tr>
 </table>
 </blockquote>
@@ -685,6 +685,7 @@ if you can provide a URL that exercises all the options that require testing.
    <TR><TD class="textcontent">
    <P>
 	For those familiar with the FreeBSD ports structure, the following fields indicate their origin:
+   </P>
 
 <table class="borderless">
 <tr><td><b>Field</b></td><td><b>Origin</b></td></tr>

--- a/www/fp2-announcement.php
+++ b/www/fp2-announcement.php
@@ -39,9 +39,9 @@ for a full list of features.  The following is a short list of some of the chang
 </P>
 
 
-<TABLE class="fullwidth" CELLPADDING="4" CELLSPACING="4">
+<TABLE class="announce-notes fullwidth">
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>Face lift</B></TD>
+<TH>Face lift</TH>
 	<TD>
 	I think you can see that the fonts
 	have changed, and some page layouts are different.  It's
@@ -49,43 +49,43 @@ for a full list of features.  The following is a short list of some of the chang
 	</TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>full commit messages</B></TD>
+<TH>full commit messages</TH>
     <TD>The switch to XML input allows us to capture more data.  And provide
 	you with a link to the original commit message.  <? echo freshports_Mail_Icon(); ?>
 	</TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>directory structure</B></TD>
+<TH>directory structure</TH>
     <TD>You know the path to your favourite ports via /usr/ports.  Use the
         same path in FreshPorts (e.g <A HREF="/sysutils/portupgrade/">sysutils/portupgrade</A>).
     </TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>one-click add/remove</B></TD>
+<TH>one-click add/remove</TH>
     <TD>See a port you like? You can add it to your watch list with
         a single click. <? echo freshports_Watch_Icon_Add(); ?>
     </TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>link to commit details</B></TD>
+<TH>link to commit details</TH>
     <TD>Want to know what files were changed in this commit?  It's now
     just one click away.  One more click will take to you the FreeBSD
     CVS repository. <? echo freshports_Files_Icon(); ?>
 	</TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>pkg_info == watch list</B></TD>
+<TH>pkg_info == watch list</TH>
     <TD>pkg_info displays list of the ports installed
         on your system.  Now you can use <A HREF="/pkg_upload.php">our scripts</A>
         to use this data to upgrade your watch list!
     </TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>Search</B></TD>
+<TH>Search</TH>
     <TD>There is now a search on the front page.. in fact, it should be on every page!</TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>Graphs are back</B></TD>
+<TH>Graphs are back</TH>
     <TD>We've improved the <A HREF="/graphs.php">graphs</A>.  They are now data driven.  All we need to do is
 		add the SQL to the database, and your query is there.  Just ask us for what you want.!</TD></TR>
 </TABLE>
@@ -93,9 +93,9 @@ for a full list of features.  The following is a short list of some of the chang
 <H2>Technical changes</H2>
 The following items deal with the technical changes which have occurred.
 
-<TABLE class="fullwidth" CELLPADDING="4" CELLSPACING="4">
+<TABLE class="announce-notes fullwidth">
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>database</B></TD>
+<TH>database</TH>
 	<TD>
 	FreshPorts now uses <A HREF="https://www.postgresql.org/">PostgreSQL</A>.  Why?  Because
 	of stored procedures and transactions (yes, we know mySQL now has transactions, but it
@@ -103,7 +103,7 @@ The following items deal with the technical changes which have occurred.
 	</TD></TR>
 
 <TR>
-<TD NOWRAP VALIGN="top" ALIGN="right"><B>XML</B></TD>
+<TH>XML</TH>
 	<TD>
 	Input for FreshPorts is first converted to XML, then processed.  This will be of great
 	benefit to <A HREF="https://www.FreshSource.org/">FreshSource</A> which is the next big

--- a/www/index.php
+++ b/www/index.php
@@ -247,7 +247,7 @@ echo '&lt; ' . $Yesterday . ' &gt;';
 echo freshports_ShowFooter();
 ?>
 <? if ($User->set_focus_search) { ?>
-	<script language="JavaScript" type="text/javascript">
+	<script type="text/javascript">
 	<!--
 	document.f.query.focus();
 	// -->

--- a/www/inthenews.php
+++ b/www/inthenews.php
@@ -26,7 +26,7 @@
   </tr>
 
 <TR>
-<TD VALIGN="top">
+<TD>
 <p>This page is just a place for me to record the <? echo $FreshPortsTitle; ?> articles which appear
 on other sites.  Links are recorded in reverse chronological order (i.e. newest first).
 </p>

--- a/www/legal.php
+++ b/www/legal.php
@@ -25,17 +25,16 @@
 
 	<?php echo freshports_MainContentTable(NOBORDER); ?>
   <TR>
-    <TD class="accent" height="32">LEGAL NOTICE</TD>
+    <TD class="accent">LEGAL NOTICE</TD>
   </TR>
   <TR><TD>This page contains our obligatory legal notice.  I really don't like having to say
           these things, but given the nature of some people, I must.  For the rest of you,
           if you respect my work and my right to it, you'll have no problem.  Thanks.
   </TD></TR>
-  <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32">COPYRIGHT</TD>
+    <TD class="accent">COPYRIGHT</TD>
   </TR>
-  <TR><TD>
+  <TR><TD class="textcontent">
   <p>Copyright <?php echo COPYRIGHTYEARS; ?> Dan Langille All rights reserved.&nbsp; Copyright in
   this document is owned by Dan Langille. &nbsp; Any person is hereby authorized to
   view, copy, print, and distribute this document subject to the following conditions: <ol>
@@ -47,9 +46,8 @@
   subject of other Intellectual Property rights reserved by Dan Langille and are not
   licensed hereunder.</p>
   </TD></TR>
-  <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32">CONTENT AND LIABILITY DISCLAIMER</TD>
+    <TD class="accent">CONTENT AND LIABILITY DISCLAIMER</TD>
   </TR>
   <TR><TD>
   <p>Dan Langille shall not be responsible for any errors or omissions contained at
@@ -66,9 +64,8 @@
   contained in it, whether such damages arise in contract, negligence, tort, under statute,
   in equity, at law or otherwise. </p>
   </TD></TR>
-  <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32">FEEDBACK INFORMATION</TD>
+    <TD class="accent">FEEDBACK INFORMATION</TD>
   </TR>
   <TR><TD>
   <p>Any information provided to Dan Langille in connection with any Dan Langille
@@ -76,9 +73,8 @@
   on a non-confidential basis. Dan Langille shall be free to use such information on
   an unrestricted basis. </p>
   </TD></TR>
-  <TR><TD height="20"></TD></TR>
   <TR>
-    <TD class="accent" height="32">TRADEMARKS</TD>
+    <TD class="accent">TRADEMARKS</TD>
   </TR>
   <TR><TD>
   <p>All Dan Langille's product names are trademarks or registered trademarks of Dan Langille

--- a/www/now-in-maintenance-mode.php
+++ b/www/now-in-maintenance-mode.php
@@ -49,7 +49,7 @@ The website is now in maintenance mode. No updates are allowed during this proce
 This page will reload every <?php echo MAINTENANCE_MODE_RERESH_TIME_SECONDS; ?> seconds. When maintence mode finishes, this page will be redirect to the home page.
 </p>
 
-<p align="center">
+<p class="maintenance">
 <img src="images/work-in-progress.jpg" width="640" height="480" alt="work in progress">
 </p>
 

--- a/www/release-2004-10.php
+++ b/www/release-2004-10.php
@@ -157,7 +157,7 @@ by the Revision Details icon (<?php echo freshports_Revision_Icon(); ?>).
 The <a href="/search.php">search page</a> now allows you to search by 
 the following fields.
 <blockquote>
-<table cellpadding="5" class="borderless">
+<table class="borderless">
 <tr><td><b>Field</b></td><td><b>Origin</b></td></tr>
 <tr><td>Port Name</td><td><code class="code">PORTNAME</code></td></tr>
 <tr><td>Package Name</td><td><code class="code">PKGNAME</code></td></tr>

--- a/www/search.php
+++ b/www/search.php
@@ -884,7 +884,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
   <tr>
 	<? echo freshports_PageBannerText("The FreshPorts Search"); ?>
   </tr>
-<tr><td valign="top">
+<tr><td>
 
 
 <form ACTION="<? echo $_SERVER["PHP_SELF"] ?>" name="search" >
@@ -928,15 +928,15 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
 
 	<BR><br>
 
-<table cellpadding="5" class="bordered">
+<table class="search-options bordered">
 <tr>
-<td valign="middle">
+<td>
 	<INPUT TYPE=checkbox <? if ($deleted == INCLUDE_DELETED_PORTS) echo 'CHECKED'; ?> VALUE=<?php echo INCLUDE_DELETED_PORTS; ?> NAME=deleted> Include deleted ports
 </td>
-<td valign="middle">
+<td>
 	<INPUT TYPE=checkbox <? if ($casesensitivity == "casesensitive")   echo 'CHECKED'; ?> VALUE=casesensitive   NAME=casesensitivity> Case sensitive search
 </td>
-<td valign="middle">
+<td>
 	Sort by: <SELECT name="orderby">
 		<OPTION VALUE="<?php echo ORDERBYPORT;       ?>" <?if ($orderby == ORDERBYPORT       ) echo 'SELECTED' ?>>Port
 		<OPTION VALUE="<?php echo ORDERBYCATEGORY;   ?>" <?if ($orderby == ORDERBYCATEGORY   ) echo 'SELECTED' ?>>Category

--- a/www/search.php
+++ b/www/search.php
@@ -1150,7 +1150,7 @@ echo freshports_ShowFooter();
 
 ?>
 <? if (!IsSet($_REQUEST['query'])) { ?>
-<script language="JavaScript" type="text/javascript">
+<script type="text/javascript">
 <!--
 document.search.query.focus();
 // -->

--- a/www/search.php
+++ b/www/search.php
@@ -304,7 +304,7 @@ if ($output_format == OUTPUT_FORMAT_HTML) {
   <tr>
 	<? echo freshports_PageBannerText("Search FreshPorts using Google"); ?>
   </tr>
-<tr><td valign="top">
+<tr><td><div class="gcse-search"></div>
 <?
 } // end of HTML only output
 

--- a/www/vuxml.php
+++ b/www/vuxml.php
@@ -23,6 +23,7 @@
 
 		$vidArray = explode('|', $vid);
 	}
+	echo HTML_DOCTYPE;
 ?>
 <html lang="en">
 <head>

--- a/www/watch-list.php
+++ b/www/watch-list.php
@@ -20,7 +20,7 @@
 	if ($_POST["Origin"]) {
 		$Origin = pg_escape_string($_POST["Origin"]);
 	} else {
-		$Origin = $_SERVER["HTTP_REFERER"];
+		$Origin = $_SERVER["HTTP_REFERER"] ? $_SERVER["HTTP_REFERER"] : '/';
 	}
 	$Redirect = 1;
 #phpinfo();


### PR DESCRIPTION
Builds off #281.

This makes most of the remaining public pages that don't require a login use valid HTML5 markup.

Todo:
- pages that require a login
- vuxml: This doesn't have a stylesheet at the moment, not sure how much we should change it?
- Switch to HTML5 doctype and resync stylesheets with non-quirksmode defaults