### PR TITLE
Packages table: CSS tooltip

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1074,10 +1074,10 @@ class port_display {
 
 						# If showing a - for the version, center align it
 						$title = $this->packageToolTipText($package_line['last_checked_latest'], $package_line['repo_date_latest'], $package_line['processed_date_latest']);
-						$HTML .= '<td class="version ' . ($package_version_latest    == '-' ? 'noversion' : '') . '" title="' . $title . '">' . $package_version_latest    . '</td>';
+						$HTML .= '<td tabindex="-1" class="version ' . ($package_version_latest    == '-' ? 'noversion' : '') . '" data-title="' . $title . '">' . $package_version_latest    . '</td>';
 
 						$title = $this->packageToolTipText($package_line['last_checked_quarterly'], $package_line['repo_date_quarterly'], $package_line['processed_date_quarterly']);
-						$HTML .= '<td class="version ' . ($package_version_quarterly == '-' ? 'noversion' : '') . '" title="' . $title . '">' . $package_version_quarterly . '</td>';
+						$HTML .= '<td tabindex="-1" class="version ' . ($package_version_quarterly == '-' ? 'noversion' : '') . '" data-title="' . $title . '">' . $package_version_quarterly . '</td>';
 						$HTML .= '</tr>';
 					}
 					$HTML .= '</table>&nbsp;';

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -424,9 +424,23 @@ table.bordered > tbody > tr > td, table.bordered > tbody > tr > th {
   border: 1px inset black;
 }
 
-td.version:hover {
+td.version:hover, td.version:focus {
   background-color: #777;
   color: white;
+  position: relative;
+}
+
+td.version:hover::after, td.version:focus::after {
+  content: attr(data-title);
+  position: absolute;
+  width: auto;
+  padding: .5em;
+  border: 1px solid black;
+  font-family: monospace;
+  text-align: left;
+  white-space: pre;
+  background-color: white;
+  color: black;
 }
 
 .packages .version.noversion, .footer, .maintenance, .fp-banner {


### PR DESCRIPTION
Rather than relying on the title attribute, show the timestamp information directly in CSS when in the :hover state. This removes the delay where you have to 'linger' on the cell to get it to appear so should make this feature easier to discover.

For touch devices, also show it on :focus, and you can now click on the cells to keep the information visible; this is also better for certain classes of accessibility since you don't need to keep the pointer still to see the content. As a bonus if you _do_ have a pointer, you can use this to compare the value of multiple cells a bit more easily. That you can click the cells isn't very discoverable, though, but that's a bit more challenging to solve without actually just saying as much.

The new tooltip is very basic and pretty ugly, but we can adjust it however we like now that it's in our control. Stuck with white background, black text, monospace font for now.

e.g. https://a.freshports.org/sysutils/rsyslog8/

Related to #280 