### PR TITLE
HTML Cleanup: User-specific pages

### DIFF
--- a/include/new-user.php
+++ b/include/new-user.php
@@ -13,25 +13,25 @@
           <TR>
             <TD>
 <?php if (IsSet($Customize)) { ?>
-               Current password:<br>
-               <INPUT TYPE="PASSWORD" NAME="Password" VALUE="<?php if (IsSet($Password)) echo htmlentities($Password) ?>" size="20"><br><br>
+              <label>Current password:<br>
+              <INPUT TYPE="PASSWORD" NAME="Password" VALUE="<?php if (IsSet($Password)) echo htmlentities($Password) ?>" size="20"></label><br><br>
 
 <?php } else { ?>
 
               <INPUT TYPE="hidden" NAME="ADD" VALUE="1">
-              User ID:<br>
-              <INPUT SIZE="15" NAME="UserLogin" VALUE="<?php if (IsSet($UserLogin)) echo htmlentities($UserLogin) ?>" autofocus=""><br><br>
+              <label>User ID:<br>
+              <INPUT SIZE="15" NAME="UserLogin" VALUE="<?php if (IsSet($UserLogin)) echo htmlentities($UserLogin) ?>" autofocus=""></label><br><br>
 <?php } ?>
-               New password:<br>
-               <INPUT TYPE="PASSWORD" NAME="Password1" VALUE="<?php if (IsSet($Password1)) echo htmlentities($Password1) ?>" size="20"><br><br>
-               New password again:<br>
-               <INPUT TYPE="PASSWORD" NAME="Password2" VALUE="<?php if (IsSet($Password2)) echo htmlentities($Password2) ?>" size="20">
+              <label>New password:<br>
+              <INPUT TYPE="PASSWORD" NAME="Password1" VALUE="<?php if (IsSet($Password1)) echo htmlentities($Password1) ?>" size="20"></label><br><br>
+              <label>New password again:<br>
+              <INPUT TYPE="PASSWORD" NAME="Password2" VALUE="<?php if (IsSet($Password2)) echo htmlentities($Password2) ?>" size="20"></label>
             </TD>
-            <TD VALIGN="top">
-               email address (required):<br>
-               <INPUT SIZE="35" NAME="email" VALUE="<?php if (IsSet($email)) echo htmlentities($email) ?>">
+            <TD>
+              <label>Email Address (required):<br>
+              <INPUT type="email" SIZE="35" NAME="email" required VALUE="<?php if (IsSet($email)) echo htmlentities($email) ?>"></label>
 
-Number of Days to show in side-bar: 
+Number of Days to show in side-bar:
 
 <SELECT NAME="numberofdays" size="1">
     <OPTION <?php if ($numberofdays == "0") echo "selected " ?> VALUE="0">0</OPTION>
@@ -46,9 +46,12 @@ Number of Days to show in side-bar:
     <OPTION <?php if ($numberofdays == "9") echo "selected " ?> VALUE="9">9</OPTION>
 </SELECT>
 
+<label>
 Set focus to search box: <input type="checkbox" id="set_focus_search" name="set_focus_search" value="set_focus_search"<?php if ($set_focus_search) echo ' checked'; ?>>
+</label>
 
-<br><br><BR>
+
+<br><br><br>
 
 Number of results to display per page (e.g commits per page):
 <?php
@@ -57,7 +60,7 @@ Number of results to display per page (e.g commits per page):
 	  echo $PageOptions->DDLB_Choices('page_size', $page_size);
 
 ?>
-<br><br><BR>
+<br><br><br>
             <INPUT TYPE="submit" VALUE="<? if (IsSet($Customize)) { echo "update";} else { echo "create";} ?> account" NAME="submit">
             <INPUT TYPE="reset"  VALUE="reset form">
             </TD>

--- a/include/new-user.php
+++ b/include/new-user.php
@@ -9,9 +9,9 @@
 ?>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE width="*" class="borderless">
+<TABLE class="borderless">
           <TR>
-            <TD VALIGN="top">
+            <TD>
 <?php if (IsSet($Customize)) { ?>
                Current password:<br>
                <INPUT TYPE="PASSWORD" NAME="Password" VALUE="<?php if (IsSet($Password)) echo htmlentities($Password) ?>" size="20"><br><br>
@@ -70,10 +70,10 @@ if ( $_SERVER['SCRIPT_NAME'] == '/new-user.php' )
 {
 ?>
 
-<tr><td align="center">CAPTCHA:<br>
+<tr><td class="captcha">CAPTCHA:<br>
   (antispam code, 3 black symbols)<br>
   <table><tr><td><img src="/images/captcha/captcha.php" alt="captcha image"></td><td><input type="text" name="captcha" size="3" maxlength="3"></td></tr></table>
-</td></tr>
+</td><td></td></tr>
 <?php
 }
 ?>    
@@ -85,6 +85,6 @@ if ( $_SERVER['SCRIPT_NAME'] != '/new-user.php' )
 {
 ?>
 <p>For your reporting needs, please visit <A HREF="/report-subscriptions.php">Report Subscriptions</A>.</p>
-<h2><a href="/delete-account.php"><big>Delete my account</big></a></h2>
+<h2><a href="/delete-account.php">Delete my account</a></h2>
 <?php
 }

--- a/include/spam-filter-information.php
+++ b/include/spam-filter-information.php
@@ -6,16 +6,17 @@
 	#
 
 ?>
+<h2>SPAM FILTERS:</h2>
 <p>
-<BIG><BIG>SPAM FILTERS:</BIG></BIG> If you are using spam filters which require confirmation
+If you are using spam filters which require confirmation
 of incoming email, these reports will be coming from the following domains:
 </p>
 
-<TABLE class="bordered" CELLPADDING="5">
-<TR><TD>domain</TD><TD>reason</TD></TR>
-<TR><TD NOWRAP><CODE CLASS="code">freshports.org</CODE></TD><TD>All reports originate from that domain.</TD></TR>
-<TR><TD NOWRAP><CODE CLASS="code">unixathome.org</CODE></TD><TD>The websites are hosted on a box in that domain.</TD></TR>
-<TR><TD NOWRAP><CODE CLASS="code">langille.org</CODE></TD><TD>If I need to write to you, it will come from that domain.</TD></TR>
+<TABLE class="spam-info bordered">
+<TR><TD>Domain</TD><TD>Reason</TD></TR>
+<TR><TD><CODE CLASS="code">freshports.org</CODE></TD><TD>All reports originate from that domain.</TD></TR>
+<TR><TD><CODE CLASS="code">unixathome.org</CODE></TD><TD>The websites are hosted on a box in that domain.</TD></TR>
+<TR><TD><CODE CLASS="code">langille.org</CODE></TD><TD>If I need to write to you, it will come from that domain.</TD></TR>
 </TABLE>
 
 <p>

--- a/include/watch-lists.php
+++ b/include/watch-lists.php
@@ -76,19 +76,13 @@ function freshports_WatchListSelectGoButton($name = 'watch_list_select') {
 function freshports_WatchListDDLBForm($db, $UserID, $WatchListID, $Extra = '') {
 	
 	$HTML = '
-<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" NAME=f>
-<table class="borderless">
-<tr>
-<td>
+<form class="watchlist-selector" action="' . $_SERVER["PHP_SELF"] . '" method="POST" NAME=f>
 ';
 
 	$HTML .= freshports_WatchListDDLB($db, $UserID, $WatchListID);
 
 $HTML .=  '
-</td>
-<td>
-'  . freshports_WatchListSelectGoButton() . $Extra .
-'</td></tr></table></form>
+'  . freshports_WatchListSelectGoButton() . $Extra .  '</form>
 ';
 
 	return $HTML;

--- a/include/watch-lists.php
+++ b/include/watch-lists.php
@@ -70,7 +70,7 @@
 	}
 
 function freshports_WatchListSelectGoButton($name = 'watch_list_select') {
-	return '	<input type="image" name="' . $name . '" value="GO" src="/images/go.gif" alt="Go" align="middle" title="Display the selected watch list">';
+	return '	<input type="image" name="' . $name . '" src="/images/go.gif" alt="Go" title="Display the selected watch list">';
 }
 
 function freshports_WatchListDDLBForm($db, $UserID, $WatchListID, $Extra = '') {
@@ -79,16 +79,14 @@ function freshports_WatchListDDLBForm($db, $UserID, $WatchListID, $Extra = '') {
 <form action="' . $_SERVER["PHP_SELF"] . '" method="POST" NAME=f>
 <table class="borderless">
 <tr>
-<td valign="top" nowrap align="right">
-<small>
+<td>
 ';
 
 	$HTML .= freshports_WatchListDDLB($db, $UserID, $WatchListID);
 
 $HTML .=  '
-</small>
 </td>
-<td valign="top" nowrap align="left">
+<td>
 '  . freshports_WatchListSelectGoButton() . $Extra .
 '</td></tr></table></form>
 ';

--- a/www/backend/watch-list.php
+++ b/www/backend/watch-list.php
@@ -37,7 +37,6 @@ function DisplayNewsFeed($db, $format, $token) {
 function DisplayWatchListNewsFeeds($db, $UserID) {
 	$Debug = 0;
 
-	echo '<h1>These are your newsfeeds</h1>';
 	$WatchLists = new WatchLists($db);
 	$NumRows = $WatchLists->Fetch($UserID);
 
@@ -57,8 +56,6 @@ function DisplayWatchListNewsFeeds($db, $UserID) {
 		}
 	}
 
-	$HTML .= '</select>';
-	
 	$HTML .= "<p>You can use these formats:
 	
 	<ul>
@@ -99,5 +96,35 @@ function DisplayWatchListNewsFeeds($db, $UserID) {
 			exit;  /* Make sure that code below does not get executed when we redirect. */
 		}
 
+		$Title = "Watch List Feeds";
+		freshports_Start($Title, $Title, 'FreeBSD, index, applications, ports');
+		echo freshports_MainTable();
+		echo '<tr><td class="content">';
+		echo freshports_MainContentTable();
+		echo '<tr>';
+		echo freshports_PageBannerText('These are your news feeds');
+		echo '</tr><TR><TD class="textcontent">';
+
 		DisplayWatchListNewsFeeds($db, $User->id);
-	}
+		?>
+	</TD></TR>
+</table>
+</td>
+
+  <td class="sidebar">
+	<?php
+	echo freshports_SideBar();
+	?>
+  </td>
+
+</tr>
+</table>
+
+<?php
+echo freshports_ShowFooter();
+?>
+
+</body>
+</html>
+<?php
+	} ?>

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -96,6 +96,7 @@ td.content {
 .files-list td, .files-list th,
 .search-options td, .search-options th,
 .spam-info td, .spam-info th,
+.watch-categories td, .watch-categories th,
 .textcontent table td, .textcontent table th {
   padding: 5px;
 }
@@ -229,6 +230,18 @@ td.captcha {
 
 .spam-info {
   margin-top: 1em;
+}
+
+table.maincontent table.watch-categories {
+  margin: 2em auto;
+}
+
+.watch-categories td {
+  vertical-align: top;
+}
+
+input[type="image"] {
+  vertical-align: middle;
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -218,6 +218,14 @@ td.summary-cell {
   margin: auto;
 }
 
+td.captcha {
+  text-align: center;
+}
+
+.captcha table {
+  margin: auto;
+}
+
 IMG#fp-logo { max-width: 100%; height: auto }
 
 CODE.code { color: #461b7e}

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -95,6 +95,7 @@ td.content {
 .ports-updating td, .ports-updating th,
 .files-list td, .files-list th,
 .search-options td, .search-options th,
+.spam-info td, .spam-info th,
 .textcontent table td, .textcontent table th {
   padding: 5px;
 }
@@ -224,6 +225,10 @@ td.captcha {
 
 .captcha table {
   margin: auto;
+}
+
+.spam-info {
+  margin-top: 1em;
 }
 
 IMG#fp-logo { max-width: 100%; height: auto }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -254,7 +254,11 @@ table.maincontent table.watch-categories {
   vertical-align: top;
 }
 
-input[type="image"] {
+.watchlist-selector {
+  float: right;
+}
+
+input[type="image"], .watchlist-selector select {
   vertical-align: middle;
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -97,8 +97,18 @@ td.content {
 .search-options td, .search-options th,
 .spam-info td, .spam-info th,
 .watch-categories td, .watch-categories th,
+.watch-maintenance table td, .watch-maintenance table th,
 .textcontent table td, .textcontent table th {
   padding: 5px;
+}
+
+.watch-maintenance td {
+  vertical-align: top;
+}
+
+.watch-maintenance input[type="submit"] {
+  width: 85px;
+  height: 24px;
 }
 
 .report-list td, .report-list th {

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -101,6 +101,10 @@ td.content {
   padding: 5px;
 }
 
+.report-list td, .report-list th {
+  padding: 3px;
+}
+
 .announce-notes {
   border-spacing: 4px;
 }
@@ -124,7 +128,7 @@ td.content {
   width: 100%;
 }
 
-.commit-details {
+.commit-details, .report-list td {
   vertical-align: top;
   white-space: nowrap;
 }

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -91,6 +91,8 @@ td.content {
 }
 
 .commit-list td, .commit-list th,
+.pkg-upload-info > tbody > tr > td, .pkg-upload-info > tbody > tr > th,
+.pkg-upload-info table.bordered td, .pkg-upload-info table.bordered th,
 .ports-moved td, .ports-moved th,
 .ports-updating td, .ports-updating th,
 .files-list td, .files-list th,
@@ -242,8 +244,26 @@ td.captcha {
   margin: auto;
 }
 
-.spam-info {
+.spam-info, .pkg-upload-info {
   margin-top: 1em;
+}
+
+.pkg-upload-info table.bordered {
+  margin: auto;
+}
+
+.pkg-upload-controls {
+  display: block;
+  margin: auto;
+  text-align: center;
+}
+
+.pkg-upload-controls > input, .pkg-upload-controls > select {
+  vertical-align: middle;
+}
+
+.pkg-upload-info td {
+  vertical-align: top;
 }
 
 table.maincontent table.watch-categories {

--- a/www/customize.php
+++ b/www/customize.php
@@ -98,7 +98,7 @@ if (IsSet($submit)) {
 	if ($OK) {
 		// get the existing email in case we need to reset the bounce count
 		$sql = "select email from users where cookie = '$visitor'";
-		$result = pg_exec($db, $sql);
+		$result = pg_query($db, $sql);
 		if ($result) {
 			$myrow = pg_fetch_array ($result, 0);
 
@@ -122,10 +122,10 @@ UPDATE users
 			$sql .= " where cookie = '$visitor'";
 
 			if ($Debug) {
-				echo '<pre>' . htmlentities($sql) . '</ore>';
+				echo '<pre>' . htmlentities($sql) . '</pre>';
 			}
 
-			$result = pg_exec($db, $sql);
+			$result = pg_query($db, $sql);
 			if ($result) {
 				$AccountModified = 1;
 			}
@@ -158,54 +158,32 @@ UPDATE users
 	freshports_Start($Title,
 						$Title,
 						'FreeBSD, index, applications, ports');
+	echo freshports_MainTable();
 ?>
 
-<TABLE class="fullwidth borderless" ALIGN="center">
 <TR><td class="content">
-<TABLE class="fullwidth borderless">
-  <TR>
-    <TD height="20"><?php
-
+<?php echo freshports_MainContentTable(NOBORDER);
 
 if ($errors) {
-echo '<TABLE class="fullwidth borderless">
+echo '<TR><TD class="accent">Access Code Failed!</TD></TR>
 <TR>
 <TD>
-<TABLE class="fullwidth borderless">
-<TR class="accent"><TD><b>Access Code Failed!</b></TD>
-</TR>
-<TR>
-<TD>
-  <TABLE class="fullwidth borderless" CELLPADDING="3">
-  <TR VALIGN=top>
-   <TD><img src="/images/warning.gif"></TD>
-   <TD width="100%">
-  <p>Some errors have occurred which must be corrected before your login can be created.</p>';
+   <TD class="textcontent"><p><img src="/images/warning.gif"> Some errors have occurred which must be corrected before your login can be created.</p>';
 
 echo $errors;
 
 echo '<p>If you need help, please email postmaster@. </p>
- </TD>
- </TR>
- </TABLE>
 </TD>
-</TR>
-</TABLE>
-</TD>
-</TR>
-</TABLE>
-<br>';
+</TR>';
 }
 if ($AccountModified) {
-   echo "Your account details were successfully updated.";
+echo '<TR><TD class="accent">Account updated!</TD></TR>
+   <tr><td class="textcontent">Your account details were successfully updated.</td></tr>';
 } else {
 
-echo '<TABLE class="fullwidth borderless">
+echo '
 <TR>
-<TD VALIGN="top">
-<TABLE class="fullwidth borderless">
-<TR>
-<td class="accent"><BIG>Customize</BIG></td>
+<td class="accent"><span>Customize</span></td>
 </TR>
 <TR>
 <TD>';
@@ -218,19 +196,18 @@ require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/new-user.php');
 
 echo "</TD>
 </TR>
-</TABLE>
-</TD>
-</TR>
-</TABLE>";
+";
 }
 
 ?>
 
-<p>
+<tr>
+<td>
 
 <?php require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/spam-filter-information.php'); ?>
 
 </TD>
+</TR>
 </TABLE>
 </td>
 

--- a/www/new-user.php
+++ b/www/new-user.php
@@ -185,15 +185,11 @@ echo '<TABLE class="fullwidth borderless">
 <TR>
 <TD>
 <TABLE class="fullwidth borderless">
-<TR class="accent"><TD><B>Access Code Failed!</B></TD>
+<TR class="accent"><TD>Access Code Failed!</TD>
 </TR>
 <TR>
 <TD>
-  <TABLE class="fullwidth borderless" CELLPADDING=3>
-  <TR VALIGN=top>
-   <TD><IMG SRC="/images/warning.gif"></TD>
-   <TD WIDTH=100%>
-  <p>Some errors have occurred which must be corrected before your login can be created.</p>';
+  <p><IMG SRC="/images/warning.gif"> Some errors have occurred which must be corrected before your login can be created.</p>';
 
 /*
   while (list($name, $value) = each($HTTP_POST_VARS)) {
@@ -203,9 +199,6 @@ echo '<TABLE class="fullwidth borderless">
 echo $errors;
 
 echo '<p>If you need help, please email postmaster@. </p>
- </TD>
- </TR>
- </TABLE>
 </TD>
 </TR>
 </TABLE>
@@ -229,7 +222,7 @@ echo freshports_MainContentTable();
       <TR>
         <TD>
 
-<P><BIG><BIG>Please observe the following points:</BIG></BIG>
+<p class="element-details"><span>Please observe the following points:</span></p>
 
 <ul>
 <li>

--- a/www/pkg_process.inc
+++ b/www/pkg_process.inc
@@ -41,7 +41,7 @@ function HandleFileUpload($FormFileName, $Destination) {
 
 function DisplayError($error) {
 ?>
-	<TABLE class="fullwidth bordered" ALIGN="center">
+	<TABLE class="fullwidth bordered">
 	<TR><TD VALIGN=TOP>
 		<TABLE class="fullwidth">
 			<TR>
@@ -50,14 +50,8 @@ function DisplayError($error) {
 
 			<TR>
 				<TD>
-					<TABLE class="fullwidth borderless" CELLPADDING="0">
-						<TR VALIGN="top">
-							<TD VALIGN="middle"><IMG SRC="/images/warning.gif" ALT="warning"></TD>
-							<TD VALIGN="middle" width="100%">
-							<? echo $error ?>
-							</TD>
-						</TR>
-					</TABLE>
+					<IMG SRC="/images/warning.gif" ALT="warning">
+					<? echo $error ?>
 				</TD>
 			</TR>
 		</TABLE>
@@ -215,7 +209,7 @@ function UploadDisplayStagingResultsMatches($UserID, $WatchListID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
+			<TABLE class="bordered">
 			<TR><TD COLSPAN="2"><B>Port name</B> <SMALL>(<? echo $numrows ?> port<?php if ($numrows > 1) echo 's'; ?>)</SMALL></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?
@@ -272,7 +266,7 @@ function UploadDisplayStagingResultsMatchesNo($UserID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
+			<TABLE class="bordered">
 			<TR><TD><B>Port name</B> <SMALL>(<? echo $numrows ?> port<?php if ($numrows > 1) echo 's'; ?>)</SMALL></TD><TD><SMALL>search</SMALL></TD></TR>
 
 			<?
@@ -316,7 +310,7 @@ function UploadDisplayStagingResultsMatchesDuplicates($UserID, $WatchListID, $db
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
+			<TABLE class="bordered">
 			<TR><TD><B>Port name</B></TD><TD><B>Count</B></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?
@@ -378,14 +372,14 @@ function UploadDisplayWatchListItemsNotInStagingArea($WatchListID, $dbh) {
 		if ($numrows) {
 			?>
 
-			<TABLE ALIGN="center" class="bordered" CELLPADDING="5">
+			<TABLE class="bordered">
 			<TR><TD><B>Port name</B></TD><TD ALIGN="center"><SMALL>Add</SMALL></TD></TR>
 
 			<?
 			for ($i = 0; $i < $numrows; $i++) {
 				$row = pg_fetch_array($result, $i);
 
-				echo '<TR><TD ALIGN="left">';
+				echo '<TR><TD>';
 				echo LinkToPort($row["category"], $row["port"]);
 				echo '</TD>';
 

--- a/www/pkg_upload.php
+++ b/www/pkg_upload.php
@@ -65,9 +65,9 @@ function DisplayUploadForm($db, $UserID) {
 	copy/paste the results into a form.
 	</p>
 
-	<table class="fullwidth bordered" cellpadding="5">
+	<table class="pkg-upload-info fullwidth bordered">
 	<tr>
-	<td valign="top">
+	<td>
 	<h2>Uploading a file</h2>
 
 	<P>Here are the steps you should perform:</P>
@@ -104,8 +104,7 @@ function DisplayUploadForm($db, $UserID) {
 		<TABLE>
 			<TR><TD>The file name containing the output from step 1:</TD></TR>
 			<TR><TD><INPUT TYPE="file"   NAME="pkg_info" SIZE="40" ></TD></TR>
-			<TR><TD><INPUT TYPE="submit" NAME="staging"  SIZE="20" VALUE="Staging"> &lt;= Click here to go to staging area</TD></TR>
-			<tr><td><hr></td></tr>
+			<TR><TD><INPUT TYPE="submit" NAME="staging"  SIZE="20" VALUE="Staging"> &lt;= Click here to go to staging area<hr></TD></TR>
 
 			<tr><td>Use this Watch List: 
 			<?php
@@ -120,15 +119,14 @@ echo freshports_WatchListDDLB($db, $UserID);
 	</FORM>
 
 	</td>
-	<td valign="top">
+	<td>
 	<h2>Copy/Paste</h2>
 
 	<FORM ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" METHOD="post" enctype="multipart/form-data">
 		<TABLE>
 			<TR><TD>Paste the output of <code>pkg info -qoa</code> here:</TD></TR>
 			<tr><td><textarea name="copypaste" rows="20" cols="30"></textarea></td></tr>
-			<TR><TD><INPUT TYPE="submit" NAME="staging_copypaste" SIZE="20" VALUE="Staging"> &lt;= Click here to go to staging area</TD></TR>
-			<tr><td><hr></td></tr>
+			<TR><TD><INPUT TYPE="submit" NAME="staging_copypaste" SIZE="20" VALUE="Staging"> &lt;= Click here to go to staging area<hr></TD></TR>
 
 			<tr><td>Use this Watch List: 
 			<?php
@@ -152,56 +150,49 @@ echo freshports_WatchListDDLB($db, $UserID);
 
 function DisplayStagingArea($UserID, $WatchListID, $db) {
 
-	echo '<TABLE ALIGN="center" class="bordered" CELLPADDING="5">';
+	echo '<TABLE class="pkg-upload-info fullwidth bordered">';
 ?>
 
-	<TR><TD COLSPAN="4"><BIG>The following information is in your Staging Area.  To save it to a Watch List, 
+	<TR><TD COLSPAN="4">The following information is in your Staging Area.  To save it to a Watch List,
 		please click on the
-			"Update watch list" button.</BIG> <SMALL><A HREF="/help.php">help</A></SMALL></TD></TR>
+			"Update watch list" button. <SMALL><A HREF="/help.php">help</A></SMALL></TD></TR>
 
 	<TR><TD COLSPAN="4">
-	<FORM ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
-	<table class="fullwidth borderless">
-	<tr><td align="center">
+	<form class="pkg-upload-controls" ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
 			<INPUT TYPE="submit" VALUE="Update watch list"  NAME="update_watch_list" SIZE="40">
-			&nbsp;&nbsp;&nbsp;
  			<INPUT TYPE="submit" VALUE="Empty staging area" NAME="clear">
-	</td><td align="right">
 			<?php echo freshports_WatchListDDLB($db, $UserID, $WatchListID); ?>
-	</td><td>
-	<?php echo freshports_WatchListSelectGoButton() ?>
-	</tr></table>
+			<?php echo freshports_WatchListSelectGoButton() ?>
 	</form>
-
 	</TD></TR>
 	<tr>
 <?
 
-	echo '<TD VALIGN="top"><B>Ports found from your uploaded data.</B><BR>Those marked with a W are already on your watch list.</TD>' . "\n";
-	echo '<TD VALIGN="top"><B>Ports not found.</B><BR>These ports are installed on your system but could not be located within FreshPorts.  Perhaps they have
+	echo '<TD><B>Ports found from your uploaded data.</B><BR>Those marked with a W are already on your watch list.</TD>' . "\n";
+	echo '<TD><B>Ports not found.</B><BR>These ports are installed on your system but could not be located within FreshPorts.  Perhaps they have
 								been renamed or removed from the ports tree.  You could use the search link, locate the ports, and add them to your
 								watch list manually.</TD>' . "\n";
-	echo '<TD VALIGN="top"><B>Ports duplicated</B><BR>The following ports have been installed multiple times, most definitely with different versions on
+	echo '<TD><B>Ports duplicated</B><BR>The following ports have been installed multiple times, most definitely with different versions on
 										 your system.</TD>' . "\n";
 
-	echo '<TD VALIGN="top"><B>Port from your watch lists</B><BR>These ports are on your watch list but do not appear in your pkg info data.</TD>' . "\n";
+	echo '<TD><B>Port from your watch lists</B><BR>These ports are on your watch list but do not appear in your pkg info data.</TD>' . "\n";
 
 	echo '</TR><TR>';
 
 
-	echo '<TD VALIGN="top">' . "\n";
+	echo '<TD>' . "\n";
 	UploadDisplayStagingResultsMatches($UserID, $WatchListID, $db);
 	echo '</TD>';
 
-	echo '<TD VALIGN="top">' . "\n";
+	echo '<TD>' . "\n";
 	UploadDisplayStagingResultsMatchesNo($UserID, $db);
 	echo '</TD>';
 
-	echo '<TD VALIGN="top">' . "\n";
+	echo '<TD>' . "\n";
 	UploadDisplayStagingResultsMatchesDuplicates($UserID, $WatchListID, $db);
 	echo '</TD>';
 
-	echo '<TD VALIGN="top">' . "\n";
+	echo '<TD>' . "\n";
 	UploadDisplayWatchListItemsNotInStagingArea($WatchListID, $db);
 	echo '</TD>';
 
@@ -211,29 +202,22 @@ function DisplayStagingArea($UserID, $WatchListID, $db) {
 
 function ChooseWatchLists($UserID, $db) {
 
-	echo '<TABLE class="fullwidth bordered" ALIGN="center" CELLPADDING="5"><TR>';
+	echo '<TABLE class="pkg-upload-info fullwidth bordered"><TR>';
 ?>
 
-	<TR><TD><BIG>Your staging area contains your uploaded information.  Please choose a watch list, and click on Go.
+	<TR><TD>Your staging area contains your uploaded information.  Please choose a watch list, and click on Go.
 		 <SMALL><A HREF="/help.php">help</A></SMALL></TD></TR>
 
 	<TR><TD>
-	<table class="fullwidth borderless"><tr><td>
-			<FORM ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
-			<P ALIGN="center">
+			<FORM class="pkg-upload-controls" ACTION="<? echo $_SERVER["PHP_SELF"]; ?>" method="POST">
  			<INPUT TYPE="submit" VALUE="Empty staging area" NAME="clear">
- 			</td><td align="right">
 			<?php echo freshports_WatchListDDLB($db, $UserID); ?>
-			</td>
-			<td>
-	<?php echo freshports_WatchListSelectGoButton() ?>
-
-</td></tr></table>
+			<?php echo freshports_WatchListSelectGoButton() ?>
+			</FORM>
 	</TD></TR>
-<?
-	echo '</FORM>';
 
-	echo '</TABLE>';
+	</TABLE>
+	<?php
 }
 
 ?>
@@ -246,7 +230,7 @@ function ChooseWatchLists($UserID, $db) {
 <TR>
 	<? echo freshports_PageBannerText("Uploading pkg info"); ?>
 <TR><TD>
-<BIG>WARNING</BIG>: The system will clear out your staging area from time to time.
+<span class="element-details">WARNING</span>: The system will clear out your staging area from time to time.
 </TD></TR>
 <TR><TD>
 	<?
@@ -381,8 +365,8 @@ if ($Debug) echo 'at line ' . __LINE__ . '<br>';
 							}
 
 							if (!IsSet($WatchListID) || $WatchListID === '') {
-								syslog(LOG_NOTICE, "No watch list ID was supplied.  I cannot continue.  pkg_upload.php::250 " .
-									"User id = " . $User->id);
+								syslog(LOG_NOTICE, "No watch list ID was supplied.  I cannot continue.  pkg_upload.php::" . __LINE__ .
+									" User id = " . $User->id);
 								die('No watch list ID was supplied.  I cannot continue.');
 							} 
 
@@ -470,7 +454,7 @@ if ($Debug) echo '<br>' . __LINE__ . '<br>';
 		#
 		if ($DisplayStagingArea) {
 			if ($WatchListUpdated) {
-				DisplayError('<BIG>Your watch list has been updated. You may wish to empty your staging area now.</BIG>');
+				DisplayError('Your watch list has been updated. You may wish to empty your staging area now.');
 			}
 			if ($WatchListID) {
 				DisplayStagingArea($User->id, $WatchListID, $db);

--- a/www/report-subscriptions.php
+++ b/www/report-subscriptions.php
@@ -36,11 +36,11 @@
 		          from report_frequency
 		         order by id';
 
-		$result = pg_exec($dbh, $sql);
+		$result = pg_query($dbh, $sql);
 		if ($result) {
 			$numrows = pg_numrows($result);
 			for ($i = 0; $i < $numrows; $i++) {
-				$myrow = pg_fetch_array ($result, $i);
+				$myrow = pg_fetch_array($result, $i);
 				# we don't include don't notify me.
 				if ($myrow['frequency'] != 'Z') {
 					$Frequencies[$myrow['id']] = $myrow['description'];
@@ -57,7 +57,7 @@
 		if ($result) {
 			$numrows = pg_numrows($result);
 			for ($i = 0; $i < $numrows; $i++) {
-				$myrow = pg_fetch_array ($result, $i);
+				$myrow = pg_fetch_array($result, $i);
 				$Values['name']				= $myrow['name'];
 				$Values['needs_frequency']	= $myrow['needs_frequency'];
 				$Values['description']		= $myrow['description'];
@@ -69,11 +69,11 @@
 	}
 
 	if (IsSet($_POST['submit']) && $_POST['submit'] == 'update') {
-		pg_exec($db, 'begin');
+		pg_query($db, 'begin');
 		$sql = "DELETE from report_subscriptions
     	         WHERE user_id = $User->id";
 
-		$result  = pg_exec($db, $sql);
+		$result = pg_query($db, $sql);
 
 		$reports = $_REQUEST['reports'];
 		if (Is_Array($reports)) {
@@ -92,7 +92,7 @@
 					$sql = "INSERT INTO report_subscriptions(report_id, user_id) values ($value, $User->id)";
 				}
 				if ($Debug) echo "\$sql='$sql'<BR>\n";
-				$result = pg_exec ($db, $sql);
+				$result = pg_query($db, $sql);
 	
 				if (!$result) {
 					echo 'OUCH, that\'s not very nice.  something went wrong: ' . pg_errormessage() . "  $sql";
@@ -102,7 +102,7 @@
 			}
 		}
 	
-		pg_exec($db, 'commit');
+		pg_query($db, 'commit');
 
 	}
 
@@ -146,7 +146,7 @@
 <TD class="content">
 <TABLE class="fullwidth borderless">
 <TR>
-<td class="accent"><BIG><? echo $ArticleTitle; ?></BIG></td>
+<td class="accent"><span><? echo $ArticleTitle; ?></span></td>
 </TR>
 <TR>
 <TD>
@@ -156,8 +156,8 @@ This page allows you to select the reports you wish to receive and the frequency
 </p>
 
 <FORM ACTION="<?php echo $_SERVER["PHP_SELF"] ;?>" METHOD="POST" NAME=f>
-	<TABLE CELLPADDING="3" class="bordered">
-	<TR><TD><BIG><B>Report Name</B></BIG></TD><TD><BIG><B>Frequency</B></BIG></TD><TD><BIG><B>Description</B></BIG></TD></TR>
+	<TABLE class="report-list bordered">
+	<TR><TD class="element-details">Report Name</TD><TD class="element-details">Frequency</TD><TD class="element-details">Description</TD></TR>
 	<?
 
 
@@ -175,20 +175,20 @@ This page allows you to select the reports you wish to receive and the frequency
 			$thefrequency		= $Values["frequency"];
 		
 			echo '<TR>';
-     		echo '<TD VALIGN="top" NOWRAP>';
-			echo '<INPUT TYPE="checkbox" NAME="reports[]" value="' . $report_id . '"';
+			echo '<TD>';
+			echo '<label><INPUT TYPE="checkbox" NAME="reports[]" value="' . $report_id . '"';
 			if ($Values["selected"]) {
 				echo ' checked';
 			}
 			echo '> ' . $name;
-			echo '</TD>';
+			echo '</label></TD>';
 
 			if ($Debug) {
 				echo '$Values["frequency"]=\'' . $Values["frequency"] . '\'';
 				echo 'now processing $report_id = \'' . $report_id . '\'';
 			}
 
-            echo '<TD VALIGN="top" NOWRAP>';
+            echo '<TD>';
 			if ($needs_frequency == 't') {
 				reset($Frequencies);
 				$numrows = count($Frequencies);
@@ -225,7 +225,7 @@ This page allows you to select the reports you wish to receive and the frequency
 
 <hr>
 <p>
-<big><big>Beta mailing list</big></big>
+<h2>Beta mailing list</h2>
 <p>
 You may wish to help me test new FreshPorts features or even just get a sneak
 peek at them.  If so, I urge you to join the new Beta mailing list.  This

--- a/www/watch-categories.php
+++ b/www/watch-categories.php
@@ -70,23 +70,25 @@ if ($_REQUEST['wlid']) {
 <table class="fullwidth borderless">
 <?php # list of categories table start ?>
 <tr><td>
+<p>
 This screen contains a list of the port categories. The categories with a * beside them contain ports which are
 on your watch list. When a port changes in one of your watch categories, you will be notified by email if you have selected a 
 notification frequency within <a href="customize.php">your account</a>.
+</p>
 </td>
 
-<td valign="top">
+<td>
 <table class="borderless">
 <?php # ddlb start ?>
 <tr><td>Select...</td></tr>
-<tr><td align="left">
+<tr><td>
 
 <?php
 if ($Debug) echo 'when calling freshports_WatchListDDLBForm, $wlid = \'' . $wlid . '\'';
 echo freshports_WatchListDDLBForm($db, $User->id, $wlid);
 
 ?>
-</tr></table>
+</td></tr></table>
 
 <?php # ddlb finish ?>
 
@@ -94,11 +96,6 @@ echo freshports_WatchListDDLBForm($db, $User->id, $wlid);
 </table>
 <?php # list of categories table finish ?>
 
-</td></tr>
-
-
-<tr><td colspan="2">
-&nbsp;
 </td></tr>
 <?php
 
@@ -115,9 +112,9 @@ $sql = "
 if ($Debug) echo "<pre>$sql</pre>";
 
 
-echo '<tr><td align="center">' . "\n";
+echo '<tr><td>' . "\n";
 
-$result  = pg_exec ($db, $sql);
+$result  = pg_query($db, $sql);
 $numrows = pg_numrows($result);
 
 if ($Debug) echo "num categories being watched = $numrows<BR>";
@@ -130,7 +127,7 @@ for ($i = 0; $i < $numrows; $i++) {
 
 # categories list start
 
-$HTML  = "\n" . '<TABLE class="bordered" CELLPADDING="5">' . "\n";
+$HTML  = "\n" . '<TABLE class="watch-categories bordered">' . "\n";
 $HTML .= '<tr>';
 // get the list of categories to display
 $sql = "
@@ -140,20 +137,19 @@ $sql = "
       from categories
   order by category";
 
-$result  = pg_exec($db, $sql);  
+$result  = pg_query($db, $sql);
 $numrows = pg_numrows($result);
 $NumCategories = 0;
 for ($i = 0; $i < $numrows; $i++) {
 	$myrow = pg_fetch_array($result, $i);
+	$rows[$NumCategories] = $myrow;
 	$NumCategories++;
-	$rows[$NumCategories-1]=$myrow;
 }
 
 # how many rows will we have if we go for NUMCOLUMNS colums?
 $RowCount = ceil($NumCategories / (double) NUMCOLUMNS);
 $Row = 0;
 for ($i = 0; $i < $NumCategories; $i++) {
-	pg_fetch_array ($result, $i);
    $Row++;
 
    if ($Row > $RowCount) {
@@ -162,7 +158,7 @@ for ($i = 0; $i < $NumCategories; $i++) {
    }
 
    if ($Row == 1) {
-      $HTML .= '<td valign="top">';
+      $HTML .= '<td>';
    }
 
    $HTML .= ' <a href="/port-watch.php?category=' . $rows[$i]["category"] . '&amp;wlid=' . $wlid . '">' . $rows[$i]["category"] . '</a>';
@@ -171,7 +167,7 @@ for ($i = 0; $i < $NumCategories; $i++) {
    $HTML .= "<br>\n";
 }
 
-if ($Row != 1) {
+if ($Row >= 1) {
    $HTML .= "</td></tr>\n";
 }
 
@@ -180,10 +176,7 @@ echo $HTML;
 echo "</table>\n";
 # categories list finish
 
-} else {
-	echo '<tr>';
-} // if wlid
-?>
+} ?>
 </table>
 <?php # main article table finish ?>
 </td>

--- a/www/watch-list-maintenance.php
+++ b/www/watch-list-maintenance.php
@@ -255,37 +255,37 @@ $ErrorMessage .= CheckForNoDefaultAndAddToDefault($db, $User);
 	}
 ?>
 <tr><td>
-<table class="fullwidth borderless">
-<tr><td valign="top">
+<table class="watch-maintenance fullwidth borderless">
+<tr><td>
 
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
-<TABLE class="fullwidth bordered" CELLPADDING="5">
-<TR><td nowrap><BIG><b>Watch Lists</b></BIG></td><td><BIG><b>Actions</b></BIG> (scroll down for instructions)</td></tr>
+<TABLE class="fullwidth bordered">
+<TR><td class="element-details">Watch Lists</td><td><span class="element-details">Actions</span> (scroll down for instructions)</td></tr>
   <TR>
-    <TD valign="top">
+    <TD>
 <?php
 	echo freshports_WatchListDDLB($db, $User->id, '', 10, TRUE);
 ?>
     </TD>
     <TD>
-    <INPUT id=add         style="WIDTH: 85px; HEIGHT: 24px" type=submit size=48 value="Add"          name=add>&nbsp;&nbsp;&nbsp; 
-    <INPUT id=add_name    name=add_name    <?php if (IsSet($add_name))    echo 'value="' . $add_name    . '" '; ?>size=10><small><sup>(1)</sup></small><BR>
-    <INPUT id=rename      style="WIDTH: 85px; HEIGHT: 24px" type=submit size=23 value="Rename"       name=rename>&nbsp;&nbsp;&nbsp; 
-    <INPUT id=rename_name name=rename_name <?php if (IsSet($rename_name)) echo 'value="' . $rename_name . '" '; ?>size=10><small><sup>(1)</sup></small><BR>
+    <INPUT id=add         type=submit size=48 value="Add"          name=add>&nbsp;&nbsp;&nbsp;
+    <INPUT id=add_name    name=add_name    <?php if (IsSet($add_name))    echo 'value="' . $add_name    . '" '; ?>pattern="[a-zA-Z0-9]+" size=10><small><sup>(1)</sup></small><BR>
+    <INPUT id=rename      type=submit size=23 value="Rename"       name=rename>&nbsp;&nbsp;&nbsp;
+    <INPUT id=rename_name name=rename_name <?php if (IsSet($rename_name)) echo 'value="' . $rename_name . '" '; ?>pattern="[a-zA-Z0-9]+" size=10><small><sup>(1)</sup></small><BR>
     <?php echo "&nbsp;<small>(1) - only $ValidCharacters</small>" ?>
 		<br>
 
     <br>
-    <INPUT id=delete      style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Delete"       name=delete><br>
-    <INPUT id=delete_all  style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Delete All"   name=delete_all><br>
+    <INPUT id=delete      type=submit size=29 value="Delete"       name=delete><br>
+    <INPUT id=delete_all  type=submit size=29 value="Delete All"   name=delete_all><br>
     <br>
-    <INPUT id=empty       style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Empty"        name=empty><br>
-    <INPUT id=empty_all   style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Empty All"    name=empty_all><br>
+    <INPUT id=empty       type=submit size=29 value="Empty"        name=empty><br>
+    <INPUT id=empty_all   type=submit size=29 value="Empty All"    name=empty_all><br>
     <br>
-    <INPUT id=default     style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Set Default"  name=set_default><br>
+    <INPUT id=default     type=submit size=29 value="Set Default"  name=set_default><br>
     <br>
 
-    Confirm: <INPUT id=confirm name=confirm size=10>
+    <label>Confirm: <INPUT id=confirm name=confirm pattern="(Delete|Empty)( All)?" size=10></label>
 	 <br>(case sensitive)
 
     </TD>
@@ -293,17 +293,17 @@ $ErrorMessage .= CheckForNoDefaultAndAddToDefault($db, $User);
 </table>
 </form>
 
-</td><td valign="top">
+</td><td>
 
-<TABLE class="fullwidth bordered" CELLPADDING="5">
-<TR><td><BIG><b>Options</b></BIG></td></tr>
+<TABLE class="fullwidth bordered">
+<TR><td class="element-details">Options</td></tr>
   <TR>
-<td valign="top" nowrap>
+<td>
 When clicking on Add/Remove for a port,<br> the action should affect
 <form action="<?php echo $_SERVER["PHP_SELF"] ?>" method="POST" NAME=f>
 <INPUT type=radio name=addremove value=default<?php if ($User->watch_list_add_remove == 'default') echo ' checked'; ?>>&nbsp;the default watch list[s]<BR>
 <INPUT type=radio name=addremove value=ask<?php     if ($User->watch_list_add_remove == 'ask')     echo ' checked'; ?>>&nbsp;Ask for watch list name[s] each time<br>
-<INPUT style="WIDTH: 85px; HEIGHT: 24px" type=submit size=29 value="Set options"  name=set_options>
+<INPUT type=submit size=29 value="Set options"  name=set_options>
  </form>
 </td>
     </TR>
@@ -315,7 +315,7 @@ When clicking on Add/Remove for a port,<br> the action should affect
 
 <H2>Information</H2>
 <ul>
-<li>Names do not have to unique but it is advisable.
+<li>Names do not have to be unique but it is advisable.
 <li>Valid characters are: <?php echo $ValidCharacters; ?>
 <li>Please contact the webmaster if you want more than 5 lists.
 </ul>
@@ -347,7 +347,7 @@ When clicking on Add/Remove for a port,<br> the action should affect
 	<li><b>Set Default</b> - Sets the default watch list[s].  The default watch list[s] is/are used when:
 			<ul>
 			<li>you click on the add/remove links
-			<li>when displaying a port, the add/remove link reflects whether or not  
+			<li>when displaying a port, the add/remove link reflects whether or not that port is on this list
 			</ul>
 	</ul>
 	
@@ -359,9 +359,9 @@ When clicking on Add/Remove for a port,<br> the action should affect
 </ul>
 
 <p>
-		<sup>*</sup>These items confirmation by typing the button name in the 
+		<sup>*</sup>These items require confirmation by typing the button name in the 
 			confirmation text box (case sensitive).  Be careful: these actions cannot be undone.
-    For example, when deleting or emptying a row, you must confirm your action by typing
+    For example, when deleting or emptying a list, you must confirm your action by typing
     the button name into this field (e.g. if you click on <b>Empty All</b>",
     you must type <b>Empty All</b> into the box below in order for the action
     to be completed). This is case sensitive.<br>

--- a/www/watch.php
+++ b/www/watch.php
@@ -71,24 +71,21 @@
 <?php echo freshports_MainTable(); ?>
 
 <tr><td class="content">
-<table class="fullwidth borderless">
+<?php echo freshports_MainContentTable(NOBORDER); ?>
 <tr>
 	<? echo freshports_PageBannerText($Title); ?>
 </tr>
-<tr><td valign="top">
-<table class="fullwidth borderless">
 <tr><td>
 <?php
 if ($wlid == '') {
 	echo 'You have no watch lists.';
 } else {
 ?>
-These are the ports which are on your <a href="watch-categories.php">watch list</A>. 
-That link also occurs on the right hand side of this page, under Login.
+These are the ports which are on your <a href="/watch-categories.php">watch list</A>.
+That link also appears on the right hand side of this page, under Login.
 <?php
 }
 ?>
-</td><td valign="top" nowrap align="right">
 
 <?php
 
@@ -97,41 +94,35 @@ if ($wlid != '') {
 }
 
 ?>
-
-</td></tr>
-</table>
 </td></tr>
 <?php
 
 // make sure the value for $sort is valid
 
 echo "<tr><td>";
-if ($wlid == '') {
-} else {
-$WatchListDeletedPorts = new WatchListDeletedPorts($db);
-$rowcount = $WatchListDeletedPorts->FetchInitialise($wlid);
-if ($rowcount)
-{
-echo '<hr><p>Some of your watched ports have moved.  You are still watching the old ports.</p>';
-echo '<table class="bordered" cellpadding="5">';
-echo '<tr><td><b>Old Port</b></td><td><b>Replaced by</b></td></tr>';
-for ($i = 0; $i < $rowcount; $i++) {
-	$WatchListDeletedPorts->FetchNth($i);
+if ($wlid) {
+	$WatchListDeletedPorts = new WatchListDeletedPorts($db);
+	$rowcount = $WatchListDeletedPorts->FetchInitialise($wlid);
+	if ($rowcount) {
+		echo '<hr><p>Some of your watched ports have moved.  You are still watching the old ports.</p>';
+		echo '<table class="bordered" cellpadding="5">';
+		echo '<tr><td><b>Old Port</b></td><td><b>Replaced by</b></td></tr>';
+		for ($i = 0; $i < $rowcount; $i++) {
+			$WatchListDeletedPorts->FetchNth($i);
 
-	$OldPort = $WatchListDeletedPorts->category_old . '/' . $WatchListDeletedPorts->name_old;
-	$NewPort = $WatchListDeletedPorts->category_new . '/' . $WatchListDeletedPorts->name_new;
-	$OldURL = '<a href="/' . $OldPort . '/">' . $OldPort . '</a>';
-	$NewURL = '<a href="/' . $NewPort . '/">' . $NewPort . '</a>';
+			$OldPort = $WatchListDeletedPorts->category_old . '/' . $WatchListDeletedPorts->name_old;
+			$NewPort = $WatchListDeletedPorts->category_new . '/' . $WatchListDeletedPorts->name_new;
+			$OldURL = '<a href="/' . $OldPort . '/">' . $OldPort . '</a>';
+			$NewURL = '<a href="/' . $NewPort . '/">' . $NewPort . '</a>';
 
-	echo "<tr><td>$OldURL</td><td>$NewURL</td></td>";
-}
-echo '</table>';
+			echo "<tr><td>$OldURL</td><td>$NewURL</td></td>";
+		}
+		echo '</table>';
 
-echo '<p>You should visit the <i>Replaced By</i> link first, add that port to your watch list, then 
+		echo '<p>You should visit the <i>Replaced By</i> link first, add that port to your watch list, then
 visit the <i>Old Port</i> link and remove it from your watch list. <hr>';
 
-}
-
+	}
 }
 
 if ($wlid != '') {
@@ -176,12 +167,12 @@ echo "</td></tr>\n";
 <?php
 	if ($wlid != '') {
 	if ($OnlyThoseWithUpdatingEntries) {
-		echo '<a href="?updating">View watched ports + entries from </code>/usr/ports/UPDATING</code></a>';
+		echo '<a href="?updating">View watched ports + entries from <code>/usr/ports/UPDATING</code></a>';
 	} else {
 		if ($IncludeUpdating) {
 			echo '<a href="https://' .  $_SERVER['HTTP_HOST'] .  $_SERVER['PHP_SELF'] . '">View all watched ports</a>';
 		} else {
-			echo '<a href="?updating">View all watched ports + entries from </code>/usr/ports/UPDATING</code></a>';
+			echo '<a href="?updating">View all watched ports + entries from <code>/usr/ports/UPDATING</code></a>';
 		}
 	}
 
@@ -190,7 +181,7 @@ echo "</td></tr>\n";
 	if ($OnlyThoseWithUpdatingEntries) {
 		echo '<a href="https://' .  $_SERVER['HTTP_HOST'] .  $_SERVER['PHP_SELF'] . '">View all watched ports.</a>';
 	} else {
-		echo '<a href="?updatingonly">View only watched ports with entries in </code>/usr/ports/UPDATING</code></a>';
+		echo '<a href="?updatingonly">View only watched ports with entries in <code>/usr/ports/UPDATING</code></a>';
 	}
 	}
 
@@ -315,8 +306,8 @@ if ($wlid != '') {
 	$TextNumRowsFound .= ' found';
 
 
-	$TextNumRowsFound .= '</small>';
-	echo "</p>\n<tr><td>";
+	$TextNumRowsFound .= '</small></p>';
+	echo "\n<tr><td>";
 
 	if ($numrows > 0) {
 		// Display the first row count only if there is a port.
@@ -359,7 +350,7 @@ if ($wlid != '') {
 					echo '<DT>';
 				}
 
-				echo '<BIG><BIG><B><a href="/' . $Category . '/">' . $Category . '</a></B></BIG></BIG>';
+				echo '<span class="element-details><span><a href="/' . $Category . '/">' . $Category . '</a></span></span>';
 				if ($ShowCategoryHeaders) {
 					echo "</DT>\n<DD>";
 				}
@@ -393,7 +384,7 @@ if ($wlid != '') {
 		echo '<small> on your watch list (but only showing ' . ($numrows - $NumSkipped) . ')</small>';
 	}
 
-	echo "</p>\n</td></tr>\n";
+	echo "\n</td></tr>\n";
 
 } // end if no wlid
 


### PR DESCRIPTION
- HTML5 validation fixes for the major remaining pages that are only accessible with an account (mostly watch-list and account related pages)
- Unnest some tables
- Add some HTML labels to forms
- Tweak some HTML form validation
- Make the watch-list RSS feed page use the normal site template
