### PR TITLE
nginx: Add sample config for compression and asset caching

### DIFF
--- a/configuration/virtualhost-common.conf.sample
+++ b/configuration/virtualhost-common.conf.sample
@@ -3,6 +3,12 @@
   root          /usr/local/www/freshports/www/;
   index         index.php index.html index.htm;
 
+  gzip on;
+  gzip_vary on;
+  gzip_http_version 1.1;
+  gzip_comp_level 6;
+  gzip_types text/plain text/css text/javascript text/xml application/javascript application/json application/xml application/xml+rss;
+
   error_log	/var/log/nginx/freshports.org-error.log;
   access_log	/var/log/nginx/freshports.org-access.log combined;
 
@@ -17,6 +23,18 @@
 
   location ~ \.php$ {
     include /usr/local/www/freshports/configuration/php-processing.conf;
+  }
+
+  # css files are appended with a content hash so have long expiry
+  location /css/ {
+    expires 2y;
+    try_files $uri $uri/ /--/index.php;
+  }
+
+  # jquery libs and most images are relatively static
+  location ~ /(javascript/jquery.+\.js|images/[^/]+\.(png|gif|jpg))$ {
+    expires 6M;
+    try_files $uri $uri/ /--/index.php;
   }
 
   location / {


### PR DESCRIPTION
Suggest the use of gzip compression for text-like content types in the nginx config. This would reduce bandwidth and improve download time/page performance for most users.

Similarly, suggest long cache lifetimes for the:
- CSS file (which is decorated with a content hash so should never go stale)
- images (which are largely static or easily updated to new paths)
- Javascript libs (which are static copies of upstream libs, which we could easily identify by version if needed).

E.g. compressing the HTML returned from requesting the homepage can reduce the filesize from 188KB down to ~25KB (GZIP level 6), ~15% of the original size.