### PR TITLE
nginx: Add sample config for OCSP stapling

### DIFF
--- a/configuration/virtualhost-common-ssl.conf.sample
+++ b/configuration/virtualhost-common-ssl.conf.sample
@@ -1,7 +1,10 @@
   ssl_protocols TLSv1.2 TLSv1.3;
 
   ssl_prefer_server_ciphers on; 
-  
+
+  ssl_stapling on;
+  ssl_stapling_verify on;
+
   ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA512:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:ECDH+AESGCM:ECDH+AES256:DH+AESGCM:DH+AES256:RSA+AESGCM:!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
   ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
   ssl_session_timeout  10m;


### PR DESCRIPTION
Follow on from #290, it [looks like](https://www.webpagetest.org/result/210524_BiDcDM_c5e2747c9b6da59344ee2cc07029c9fa/1/details/#waterfall_step1) a big chunk (up to 40% for a fresh connection that needs to include DNS lookup) of our Time to First Byte is spent on the OCSP verification of the Let's Encrypt cert.

This PR adds required nginx config to enable [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling), which would prevent users needing to do this additional check to validate the certificate and load the site faster.

This similarly to #290 just updates the sample configs, but would be good to see the update migrated to the real configs dev/test and eventually prod.