### PR TITLE
HTML Fixes: package flavors and invalid message ID

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -976,13 +976,13 @@ class port_display {
 					if ($port->forbidden || $port->broken || $port->ignore || $port->restricted || !$port->PackageIsAvailable()) {
 						$HTML .= '<dt><b>A <a href="/faq.php#package" TITLE="what is a package?">package</a> is not available for ports marked as: Forbidden / Broken / Ignore / Restricted</b></dt>';
 					} else {
-						$HTML .= '<dt><b>To add the <a href="/faq.php#package" TITLE="what is a package?">package</a>, run one of these commands:</b>';
-						$HTML .= '<ul><li><code class="code">pkg install ' . $port->category . '/' . $port->port . '</code></li>';
-						$HTML .= '<li><code class="code">pkg install ' . $port->package_name . '</code></li></ol>';
+						$HTML .= '<dt><b>To add the <a href="/faq.php#package" TITLE="what is a package?">package</a>, run one of these commands:</b></dt>';
+						$HTML .= '<dd><ul><li><code class="code">pkg install ' . $port->category . '/' . $port->port . '</code></li>';
+						$HTML .= '<li><code class="code">pkg install ' . $port->package_name . '</code></li></ul>';
 						if ($this->Is_A_Python_Port()) {
-							$HTML .= 'NOTE: This is a Python port. Instead of <code class="code">' . $port->package_name . ' listed in the above command, you can pick from the names under the <a href="#packages">Packages</a> section.';
+							$HTML .= 'NOTE: This is a Python port. Instead of <code class="code">' . $port->package_name . '</code> listed in the above command, you can pick from the names under the <a href="#packages">Packages</a> section.';
 						}
-						$HTML .= '</dt>';
+						$HTML .= '</dd>';
 					}
 				}
 			}

--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -969,7 +969,7 @@ class port_display {
 				$HTML .= '<dt>No installation instructions: this port has been deleted.</dt>';
 				$HTML .= '<dt>The package name of this deleted port was: <code class="code">' . $port->latest_link . '</code></dt>';
 			} else {
-				$HTML .= '<dt><b><a id="add">To install</a> <a href="/faq.php#port" TITLE="what is a port?">the port</a>:</b> <code class="code">cd /usr/ports/'  . $port->category . '/' . $port->port . '/ && make install clean</code></dt>';
+				$HTML .= '<dt id="add"><b>To install <a href="/faq.php#port" TITLE="what is a port?">the port</a>:</b> <kbd class="code">cd /usr/ports/'  . $port->category . '/' . $port->port . '/ && make install clean</kbd></dt>';
 				if (IsSet($port->no_package) && $port->no_package != '') {
 					$HTML .= '<dt><b>No <a href="/faq.php#package" TITLE="what is a package?">package</a> is available:</b> ' . $port->no_package . '</dt>';
 					} else {
@@ -977,10 +977,10 @@ class port_display {
 						$HTML .= '<dt><b>A <a href="/faq.php#package" TITLE="what is a package?">package</a> is not available for ports marked as: Forbidden / Broken / Ignore / Restricted</b></dt>';
 					} else {
 						$HTML .= '<dt><b>To add the <a href="/faq.php#package" TITLE="what is a package?">package</a>, run one of these commands:</b></dt>';
-						$HTML .= '<dd><ul><li><code class="code">pkg install ' . $port->category . '/' . $port->port . '</code></li>';
-						$HTML .= '<li><code class="code">pkg install ' . $port->package_name . '</code></li></ul>';
+						$HTML .= '<dd><ul><li><kbd class="code">pkg install ' . $port->category . '/' . $port->port . '</kbd></li>';
+						$HTML .= '<li><kbd class="code">pkg install ' . $port->package_name . '</kbd></li></ul>';
 						if ($this->Is_A_Python_Port()) {
-							$HTML .= 'NOTE: This is a Python port. Instead of <code class="code">' . $port->package_name . '</code> listed in the above command, you can pick from the names under the <a href="#packages">Packages</a> section.';
+							$HTML .= 'NOTE: This is a Python port. Instead of <kbd class="code">' . $port->package_name . '</kbd> listed in the above command, you can pick from the names under the <a href="#packages">Packages</a> section.';
 						}
 						$HTML .= '</dd>';
 					}

--- a/www/commit.php
+++ b/www/commit.php
@@ -234,7 +234,7 @@
 							$HTML .= '<tr><TD><p>Number of ports [&amp; non-ports] in this commit: ' . $NumFilesTouched . '</p></td></tr>';
 						} else {
 							$HTML .=  '<tr><TD><P>Sorry, nothing found in the database....</P>' . "\n";
-							$HTML .=  "</TD></tr>";
+							$HTML .=  '</td></tr>';
 							$DoTheSave = false;
 						}
 					} else {
@@ -242,7 +242,7 @@
 						exit;
 					}
 
-					$HTML .=  "</TABLE>\n";
+					$HTML .=  "<tr><td>\n";
 
 					$ShowAllFilesURL = '<a href="' . htmlspecialchars($_SERVER['SCRIPT_URL'] . '?message_id=' .  $message_id . '&files=yes') . '">show all files</a>';
 
@@ -317,6 +317,8 @@
 						$Cache->CacheDataSet($HTML);
 						$Cache->AddCommit($message_id, $clean['category'], $clean['port'], $files);
 					}
+
+					$HTML .= "\n</table></td>\n";
 				} // $HTML != ''
 			} # count($message_id_array)
 

--- a/www/commit.php
+++ b/www/commit.php
@@ -134,31 +134,19 @@
 					$Title,
 					'FreeBSD, index, applications, ports');
 
-function str_is_int($str) {
-	$var = intval($str);
-	return ($str == $var);
-}
+	function str_is_int($str) {
+		$var = intval($str);
+		return ($str == $var);
+	}
 
-if ($Debug) echo "UserID='$User->id'";
+	if ($Debug) echo "UserID='$User->id'";
 
-?>
-
-	<?php echo freshports_MainTable(); ?>
+	echo freshports_MainTable(); ?>
 
 	<tr><td class="content">
 
-	<?php echo freshports_MainContentTable(BORDER); ?>
-
-<?
-	if (file_exists("announcement.txt") && filesize("announcement.txt") > 4) {
-?>
-  <TR>
-    <TD>
-       <? include ("announcement.txt"); ?>
-    </TD>
-  </TR>
-<?
-	}
+	<?php
+	echo freshports_MainContentTable(BORDER);
 
 	if ($cached) {
 		echo '<tr>' . freshports_PageBannerText($Title) . '</tr>';

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -284,7 +284,7 @@ input[type="image"], .watchlist-selector select {
 
 IMG#fp-logo { max-width: 100%; height: auto }
 
-CODE.code { color: #461b7e}
+CODE.code, kbd.code { color: #461b7e}
 PRE.code {  color: #461b7e; white-space: pre-wrap; word-break: break-word; }
 
 .like-pre {


### PR DESCRIPTION
- Fixes some validation errors introduced in the fix for #287
- Improve HTML semantics in pkg install instructions (kbd over code elements)
- Fixes commit.php page rendering when given an invalid `message_id`  (fixes #204) (also should fix #193 when combined with #292)
- Clean up old announcement handling