### PR TITLE
TTFB optimization

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -775,6 +775,8 @@ GLOBAL $ShowAds;
 GLOBAL $BannerAd;
 GLOBAL $ShowAnnouncements;
 
+	header('X-Accel-Buffering: no');
+
 	freshports_HTML_Start();
 	freshports_Header($ArticleTitle, $Description, $Keywords, $Phorum);
 
@@ -794,6 +796,8 @@ GLOBAL $ShowAnnouncements;
 		}
 	}
 
+	ob_flush();
+	flush();
 }
 
 function freshports_Logo() {


### PR DESCRIPTION
This disables nginx's page buffering when rendering HTML pages using `freshports_Start`; at the end of that call we then flush the buffers to the user so the browser can start parsing HTML earlier and downloading assets like the CSS and the site banner. This gives it something to do while we do the real work talking to the database and constructing the rest of the page.

This seems to consistently shave about 300ms off our TTFB metric on my environment, and should get most of the front-end assets loading earlier and potentially improve our First Contentful Paint (FCP) metrics by loading the header + banner of the page. FCP is considered a Core Web Vital and should improve our SEO.