### PR TITLE
Generalize holiday detection support

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -32,10 +32,11 @@ DEFINE('CLICKTOADD', 'Click to add this to your default watch list[s]');
 DEFINE('SPONSORS', 'Servers and bandwidth provided by <br><a href="https://www.nyi.net/" rel="noopener noreferrer" TARGET="_blank">New York Internet</a>, <a href="https://www.ixsystems.com/"  rel="noopener noreferrer" TARGET="_blank">iXsystems</a>, and <a href="https://www.rootbsd.net/" rel="noopener noreferrer" TARGET="_blank">RootBSD</a>');
 
 DEFINE('FRESHPORTS_ENCODING', 'UTF-8');
+DEFINE('FRESHPORTS_TIMEZONE', 'UTC');
 
 if ($Debug) echo "'" . $_SERVER['DOCUMENT_ROOT'] . '/../classes/watchnotice.php<br>';
 
-date_default_timezone_set('UTC');
+date_default_timezone_set(FRESHPORTS_TIMEZONE);
 
 require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/watchnotice.php');
 
@@ -859,12 +860,22 @@ $HTML .= '
 	return $HTML;
 }
 
+function freshports_detect_holidays($now) {
+	$month = date("n", $now);
+
+	// June is LGBTQ+ Pride Month
+	if ($month == "06") return "pride";
+
+	return '';
+}
 
 function freshports_HTML_Start() {
 GLOBAL $Debug;
 
+$holiday = freshports_detect_holidays(time());
+
 echo HTML_DOCTYPE . '
-<html lang="en">
+<html lang="en"' . ($holiday ? ' class="holiday ' . $holiday . '"' : '') . '>
 ';
 }
 

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -6,6 +6,26 @@
   box-sizing: border-box;
 }
 
+/* pride month */
+.holiday.pride {
+  background: repeating-linear-gradient(
+    #cc66ff 0, #cc66ff 2em,
+    #ff6699 2em, #ff6699 4em,
+    #ff0000 4em, #ff0000 6em,
+    #ff9900 6em, #ff9900 8em,
+    #ffff00 8em, #ffff00 10em,
+    #009900 10em, #009900 12em,
+    #0099cc 12em, #0099cc 14em,
+    #330099 14em, #330099 16em,
+    #990099 16em, #990099 18em
+  );
+  height: 100%;
+}
+
+.holiday.pride body > table {
+  background-color: white;
+}
+
 body {
   background-color: white;
   color: black;


### PR DESCRIPTION
Add a general mechanism for holiday-specific CSS decorations. 
- Adds holiday definition for LGBTQ+ Pride Month

The holiday definitions are date-based, so it should switch back to normal automatically once July rolls around.

TODO: Migrate the existing Remembrance Day decorations to display using this method, if possible.

For the LGBTQ+ Pride month colours, I went with the 2017 Gilbert Baker 9-band variant of the [Rainbow Flag](https://en.wikipedia.org/wiki/Rainbow_flag_(LGBT)) (which adds lavender to symbolise Diversity). This seems to be most in-tune with the modern and popular "Philadelphia" and "Progress Pride" variants while still keeping the purely band-based motif. I'm not really part of these communities, though, so very open to advice if we want to use another variant or just stick with the classic 6-band.