### PR TITLE
Adjust dark mode contrast

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -9,10 +9,10 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background-color: #1e1e1e;
+    --background-color: #151515;
     --body-text: #c9d9d9;
-    --code-text: #9e6edd;
-    --link-color: rgb(51, 156, 255);
+    --code-text: #dfc7ff;
+    --link-color: #33cdff;
   }
 
   a:link {


### PR DESCRIPTION
Fixes #330

Looks a bit chalky to me, but the contrast ratio is higher for sure, which should be more accessible and thus better and hopefully reads easier.

I think I based the original scheme off adjusted values from Firefox's Reader Mode dark stylesheet, thinking it'd be a good enough base.