### PR TITLE
Adjust text wrapping for pre-like elements

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -351,7 +351,8 @@ PRE.code {
   color: #461b7e;
   color: var(--code-text);
   font-family: monospace;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-all;
   margin-top: 15px;
   margin-bottom: 15px;
   margin-left: 25px;


### PR DESCRIPTION
Fixes #320.

Considered being more selective to only impact the hashes in distinfo, but then decided not breaking the site layout was more important than occasionally wrapping text too often.