### PR TITLE
Fix newsfeeds for branches

### DIFF
--- a/classes/newsfeed.php
+++ b/classes/newsfeed.php
@@ -276,7 +276,9 @@ ORDER BY CL.commit_date;
             from commit_log cl
            where exists (select *
                            from commit_log_ports clp
-                          where clp.commit_log_id = cl.id)
+                           join commit_log_branches clb on clp.commit_log_id = clb.commit_log_id
+                           join system_branch sb on sb.id = clb.branch_id
+                          where clp.commit_log_id = cl.id and sb.branch_name = " . pg_escape_literal($BranchName) . ")
            order by cl.commit_date desc limit 100 ) AS CL
     JOIN LATERAL ( select CLP1.commit_log_id, P.forbidden, P.broken, P.deprecated, P.element_id,
                           CASE when CLP1.port_version  IS NULL then P.version  else CLP1.port_version  END as version,
@@ -295,8 +297,6 @@ ORDER BY CL.commit_date;
                       and CLP1.port_id   = P.id
                   ORDER BY P.id 
                      LIMIT 1) AS CLP on true
-    JOIN commit_log_branches CLB ON CLP.commit_log_id = CLB.commit_log_id
-    JOIN system_branch       SB  ON SB.branch_name    = " . pg_escape_literal($BranchName) . " AND SB.id = CLB.branch_id
     JOIN element             E   ON CLP.element_id    = E.id
     JOIN categories          C   ON CLP.category_id   = C.id
     ORDER BY CL.commit_date desc

--- a/classes/newsfeed.php
+++ b/classes/newsfeed.php
@@ -134,12 +134,6 @@ function newsfeed($db, $Format, $WatchListID = 0, $BranchName = BRANCH_HEAD, $Fl
 	   AND WLE.watch_list_id = " . pg_escape_string($WatchListID) .  ' ';
 	   
 	} else {
-		if ($BranchName == BRANCH_HEAD) {
-			$BranchExpression = pg_escape_literal('/ports/' . BRANCH_HEAD .'/%');
-		} else {
-			$BranchExpression =  pg_escape_literal('/ports/branches/' . $BranchName . '/%');
-		}
-
 		switch ($Flavor) {
 			case 'new':
 				$sql = "


### PR DESCRIPTION
Should fix #354

Move the branch filtering logic earlier in the query; Old behavior finds the latest 100 commits that touch ports, which probably are for `head` (rather than the branch we're looking for) and so they get filtered by checking the branch later, resulting in empty results.

This makes it only look for commits that touch ports that are also on the target branch, to get the desired behavior. This should fix feeds for all historical branches, but nonexistent/new branches are now slow as it churns through history looking for 100 commits on that branch name. I'm relying on the caching to make this not a DOS threat. `head` branch should behave the same as it does now.

E.g.
Current: https://www.freshports.org/backend/html.php?branch=2021Q1
vs
Patched: https://a.freshports.org/backend/html.php?branch=2021Q1

(`branch=quarterly` should get fixed by this too, but a.freshports.org's DB is frozen at 2021Q1 and has no commits for 2022Q1, so it gets empty results at the moment).