### PR TITLE
Make it more obvious when no results are returned

### DIFF
--- a/www/search.php
+++ b/www/search.php
@@ -1053,7 +1053,7 @@ if ($search) {
 
 if ($NumFetches == 0) {
    if ($output_format == OUTPUT_FORMAT_HTML) {
-     $HTML .= " no results found<br>\n";
+     $HTML .= " <strong style=\"color:var(--beastie-red)\">No ports found</strong><br>\n";
    }
 } else {
       if ($stype == 'committer' || $stype == 'commitmessage' || $stype == 'tree') {


### PR DESCRIPTION
Maybe I’m blind, but I struggle to see the no results message. I’m probably not alone, so I made it bold and beastie red.