### PR TITLE
faq.php: some fallout lists will be empty

### DIFF
--- a/www/faq.php
+++ b/www/faq.php
@@ -245,7 +245,7 @@ down you must read to find something you didn't already know.</P>
 	There are a few symbols you will see in this website.
 
 	<P id="fallout"><?php echo freshports_Fallout_Icon(); ?>
-		Fallout: a link to search the pkg-fallout archives for this port.</P>
+		Fallout: a link to search the <a href="https://lists.freebsd.org/archives/freebsd-pkg-fallout/">freebsd-pkg-fallout archives</a>. If the resulting fallout list is empty: the port may have been skipped due to fallout of a related port.</P>
 
 	<P id="repology"><?php echo freshports_Repology_Icon(); ?>
 		Repology: a link to search the Repology packaging hub for this port.</P>


### PR DESCRIPTION
Re: <https://github.com/FreshPorts/freshports/issues/384#issuecomment-1257279011> it's not possible to distinguish between fallout and a skip, so offer an explanation for there being no fallout in response to a click on the fallout icon.