### PR TITLE
Display a greyed subversion icon if no subversion history

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -288,8 +288,15 @@ class port_display {
           if (!empty($link)) {
             $link = '<a href="' . $link . '">' . freshports_Subversion_Icon($link_title) . '</a>';
           } else {
-            $link = '<del>SVNWeb</del>';
+            $link = $this->link_to_repo_svn_greyed();
           }
+
+          return $link;
+	}
+
+	function link_to_repo_svn_greyed() {
+          $link_title = 'SVNWeb - no subversion history for this port';
+          $link = freshports_Subversion_Icon_Greyed($link_title);
 
           return $link;
 	}
@@ -1164,7 +1171,11 @@ class port_display {
 				$HTML .= ICON_SEPARATOR;
 				$HTML .= $this->_link_to_repo_git_gitlab();
 				$HTML .= ICON_SEPARATOR;
-				$HTML .= $this->link_to_repo_svn();
+				if (IsSet($port->{'date_added'}) && strtotime($port->{'date_added'}) < strtotime(LAST_SUBVERSION_COMMIT)) {
+					$HTML .= $this->link_to_repo_svn();
+				} else {
+					$HTML .= $this->link_to_repo_svn_greyed();
+				}
 			}
 
 			if ($port->PackageExists() && ($this->ShowPackageLink || $this->ShowEverything)) {

--- a/include/constants.php
+++ b/include/constants.php
@@ -218,3 +218,6 @@ define('HTML_DOCTYPE', '<!DOCTYPE html>');
 define('ICON_SEPARATOR', ' &#166; ');
 
 define('VUXML_LATEST', HTML_DIRECTORY . '/vuln-latest.html');
+
+
+define('LAST_SUBVERSION_COMMIT', '2022-10-25 18:42:09');

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -350,6 +350,10 @@ function freshports_Subversion_Icon($Title = 'Subversion') {
 	return '<img class="icon" src="/images/subversion.png" alt="' . $Title . '" title="' . $Title . '" width="32" height="32">';
 }
 
+function freshports_Subversion_Icon_Greyed($Title = 'Subversion') {
+	return '<img class="icon" src="/images/subversion-greyed.png" alt="' . $Title . '" title="' . $Title . '" width="32" height="32">';
+}
+
 function freshports_Git_Icon($Title = 'git', $size = DEFAULT_ICON_SIZE) {
 	return '<img class="icon" src="/images/git.png" alt="' . $Title . '" title="' . $Title . '" width="' . $size . '" height="' . $size . '">';
 }


### PR DESCRIPTION
The last subversion commit was on 2022-10-25 18:42:09

If the port was added before that date, it has subversion history. Otherwise, display a greyed-out subversion icon.

re: https://github.com/FreshPorts/freshports/issues/403