### PR TITLE
www/search.php: Use ISO-8859-15

### DIFF
--- a/www/search.php
+++ b/www/search.php
@@ -906,6 +906,7 @@ JOIN element_pathname EP on E.id = EP.element_id
 					echo "<pre>$sql<pre>\n";
 				}
 
+				pg_exec($db, "set client_encoding = 'ISO-8859-15'");
 				$result  = pg_exec($db, $sql);
 				if (!$result) {
 					syslog(LOG_NOTICE, pg_last_error($db) . ': ' . $sql);


### PR DESCRIPTION
Avoids Warning: pg_exec(): Query failed: ERROR: invalid byte sequence for encoding "UTF8": 0xe1 0x66 0x69 in /usr/local/www/freshports/www/search.php on line 908

fixes #447