### PR TITLE
classes/port-display.php: if no packages for this port, suggest fallout

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -1573,7 +1573,11 @@ class port_display {
 			} else {
 				$HTML .= '<dt id="packages"><hr><b>No package information for this port in our database</b></dt>';
 				$HTML .= '<dd>Sometimes this happens. Not all ports have packages.';
-				if ($MarkedAsNew) $HTML .= ' This is doubly so for new ports, like this one.';
+				if ($MarkedAsNew) {
+					$HTML .= ' This is doubly so for new ports, like this one.';
+				} else {
+					$HTML .= ' Perhaps there is a build error. Check the fallout link: ' . freshports_Fallout_Link($port->category, $port->port);
+				}
 				$HTML .= '</dd>';
 			}
 		}


### PR DESCRIPTION
Sometimes there are no packages available for a port. That may be because the build is failing for that port. Provide the fallout link here.

re: #570
classes/port-display.php# On branch 570-no-package-information-for-editorsvscode