### PR TITLE
578 fix python prefix issues arsing out of python 311 what about suffixes

### DIFF
--- a/classes/port-display.php
+++ b/classes/port-display.php
@@ -719,7 +719,7 @@ class port_display {
 
 	function Is_A_Python_Port(&$matches) {
 		# find out of the python port starts with pyXX-
-		$Is_A_Python_Port = preg_match('/^py[0-9][0-9]-(.*)/', $this->port->package_name ?? '', $matches);
+		$Is_A_Python_Port = preg_match('/^py[0-9]+-(.*)/', $this->port->package_name ?? '', $matches);
 
 		return $Is_A_Python_Port;
 	}


### PR DESCRIPTION
classes/port-display.php: Extend dependency line to consider PYTHON_PKGNAMESUFFIX

The code already does:

${PYTHON_PKGNAMEPREFIX}poetry-core>0:devel/py-poetry-core@${PY_FLAVOR}

Now it also caters for:

pylint${PYTHON_PKGNAMESUFFIX}>0:devel/pylint
