### PR TITLE
OpenSearch support

### DIFF
--- a/include/freshports.php
+++ b/include/freshports.php
@@ -1144,6 +1144,8 @@ function freshports_HEAD_main_items() {
 
 	<link rel="alternate" type="application/rss+xml" title="FreshPorts - The Place For Ports" href="https://' . $_SERVER['HTTP_HOST'] . '/backend/rss2.0.php">
 
+	<link rel="search" type="application/opensearchdescription+xml" href="https://' . $_SERVER['HTTP_HOST'] . '/opensearch.php" title="FreshPorts">
+
 	<link rel="apple-touch-icon" sizes="57x57" href="/images/apple-icon-57x57.png">
 	<link rel="apple-touch-icon" sizes="60x60" href="/images/apple-icon-60x60.png">
 	<link rel="apple-touch-icon" sizes="72x72" href="/images/apple-icon-72x72.png">

--- a/www/opensearch.php
+++ b/www/opensearch.php
@@ -1,0 +1,7 @@
+<?php header('Content-Type: application/opensearchdescription+xml; charset=utf-8'); ?>
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>FreshPorts</ShortName>
+  <Image width="16" height="16" type="image/x-icon"><?php echo 'https://' . $_SERVER['HTTP_HOST'] . '/favicon.ico' ?></Image>
+  <Url type="text/html" template="<?php echo 'https://' . $_SERVER['HTTP_HOST'] . '/search.php?query={searchTerms}' ?>" />
+</OpenSearchDescription>


### PR DESCRIPTION
This pull request adds [OpenSearch](https://en.wikipedia.org/wiki/OpenSearch) support, providing an easy way for users to add FreshPorts as a search engine to their browser[^1].

[^1]: Or in case of Firefox, allowing them to add it at all, as the ability to define custom search engines was removed.