### PR TITLE
Fix commit ports list

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -395,6 +395,10 @@ class DisplayCommit
 				}
 
 				$this->HTML .= $this->_DisplayStartofCommit($mycommit);
+
+				if ($DetailsWillBePresented) {
+					$this->HTML .= '<ul class="element-list">' . "\n";
+				}
 			}
 
 			$NumberOfPortsInThisCommit++;
@@ -403,12 +407,6 @@ class DisplayCommit
 			}
 
 			if ($Debug) echo 'at too many<br>';
-
-			if ($DetailsWillBePresented) {
-				$this->HTML .= '<ul class="element-list">' . "\n";
-			}
-
-
 
 			if (!$TooManyPorts) {
 				if ($DetailsWillBePresented) {

--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -118,7 +118,7 @@ class DisplayCommit
 			$HTML .= '&nbsp;(' . $mycommit->committer . ')';
 		}
 
-		# after the committer, display a search-by-commiter link
+		# after the committer, display a search-by-committer link
 		$HTML .= '&nbsp;' . freshports_Search_Committer($mycommit->committer);
 
 		if ($CommitterIsNotAuthor) {
@@ -167,7 +167,7 @@ class DisplayCommit
 			$HTML .= '<a href="/' . str_replace('%2F', '/', $PathName);
 			if (!empty($mycommit->port)) $HTML .= '/';
 			$HTML .= $QueryArgs . '"';
-			$HTML .= ' title="' . $PathName . ': ' . $mycommit->short_description . '"';
+			$HTML .= ' title="' . $PathName . ': ' . htmlentities($mycommit->short_description) . '"';
 			$HTML .= '>' . $PathName . '</a>';
 		} else {
 			#$HTML .= '<a href="' . FRESHPORTS_FREEBSD_CVS_URL . $PathName . '#rev' . $mycommit->revision . '">' . $PathName . '</a>';


### PR DESCRIPTION
On the homepage, as a commit is being processed, if it touches multiple ports the ports are displayed in a list.
At the moment, rather than each port being just a list item, each port also opens its own instance of the `<ul class="element-list>`, but this list is only closed once at the end of the commit processing, leaving the additional `ul` elements unclosed and producing invalid HTML.
If the number of ports is greater than `$MaxNumberPortsToShow` (10), the `ul` elements open with no content, resulting in some odd markup, e.g.:

```html
<ul class="element-list">
<li><span class="element-details"><a href="[/benchmarks/hey/](view-source:https://www.freshports.org/benchmarks/hey/)" title="benchmarks/hey: Load-based HTTP benchmarking tool">benchmarks/hey</a> 0.1.4_34</span>
 Load-based HTTP benchmarking tool</li>
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
<ul class="element-list">
```

This PR changes the template to only print one instance of `<ul class="element-list>` at the start of the commit, so it can properly close at the end of the commit before printing the description.

Also we now escape the port short description used in the port's link `title` attribute, which can contain double quotes in some cases, producing invalid markup, e.g.:

```html
<li><span class="element-details"><a href="/net/minidlna/" title="net/minidlna: Media-server compatible with "Digital Life Network Alliance"">net/minidlna</a> 1.3.3_9,1</span>
 Media-server compatible with "Digital Life Network Alliance"</li>
```

This should restore the homepage to being valid HTML.