### PR TITLE
Dark mode tweaks

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -5,6 +5,7 @@
   --accent-text: white;
   --code-text: #461b7e;
   --link-color: #36f;
+  --gsc-button: #cecece;
   color-scheme: light dark;
 }
 
@@ -14,6 +15,7 @@
     --body-text: #c9d9d9;
     --code-text: #dfc7ff;
     --link-color: #33cdff;
+    --gsc-button: var(--background-color);
   }
 
   a:link {
@@ -162,6 +164,20 @@ td.content {
 .textcontent table td, .textcontent table th {
   padding: 5px;
 }
+
+/* following nested under body for specificity */
+body .gsc-control-cse, body .gsc-input-box {
+  background-color: inherit;
+}
+
+body .gsc-control-cse input {
+  background-color: inherit !important;
+}
+
+body .gsc-search-button-v2 {
+  background-color: var(--gsc-button);
+}
+
 
 .watch-maintenance td {
   vertical-align: top;

--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -5,6 +5,7 @@
   --accent-text: white;
   --code-text: #461b7e;
   --link-color: #36f;
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Addresses some feedback from #598:

- Adds [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme) to declare support for dark mode, which should darken native browser controls like `input` elements when in dark mode
- Overrides some CSS for  the Google search box on https://www.freshports.org/search.php so it's less obnoxious in dark mode

<img width="1350" height="732" alt="Screen Shot 2025-12-04 at 22 31 06(1)" src="https://github.com/user-attachments/assets/fb852463-0c81-4c92-b5ae-df2c0dcc00cc" />
---
<img width="1350" height="732" alt="Screen Shot 2025-12-04 at 22 33 27(1)" src="https://github.com/user-attachments/assets/8144fb77-b4ec-42f5-9972-1545b959659e" />


Light mode should look as it does already.