### PR TITLE
Use bigger font on 140+ DPI displays

### DIFF
--- a/www/css/freshports.css
+++ b/www/css/freshports.css
@@ -75,6 +75,12 @@ BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
 {
     font-size: 12px;
 }
+@media only screen and (min-resolution: 140dpi) {
+  BODY, TD, TR, P, UL, OL, LI, INPUT, SELECT, DL, DD, DT, FONT
+  {
+      font-size: 18px;
+  }
+}
 
 table.maincontent > tbody > tr > td {
   padding: 8px;


### PR DESCRIPTION
I love FreshPorts, but I find current font size too small for screens with 140+ DPI

Here's small adjustment that makes fonts bigger on 140+ DPI screens.
original:
<img width="2732" height="2334" alt="image" src="https://github.com/user-attachments/assets/46804751-fe29-4a46-9978-dc7f4e434b59" />

adjusted:
<img width="2698" height="2626" alt="image" src="https://github.com/user-attachments/assets/07ac99fb-da73-409a-8f4e-b70883156aae" />
