### PR TITLE
Bots seem to abuse vuxml, commit, and search.

### DIFF
--- a/include/constants.local.php.sample
+++ b/include/constants.local.php.sample
@@ -50,3 +50,7 @@ define('HTMLIFY_USE_LIB_AUTOLINK',      true);
 define('HTMLIFY_PROCESS_PRS', true);
 
 define('INCLUDE_GOOGLE_GTAG', false);
+
+define('LOGIN_TO_VIEW_COMMIT', true);
+define('LOGIN_TO_SEARCH',      true);
+define('LOGIN_TO_VIEW_VUXML',  true);

--- a/include/freshports.php
+++ b/include/freshports.php
@@ -2755,7 +2755,9 @@ function checkLoadBeforeProceeding() {
   if ($User->id) {
     return;
   }
+
   $MaxLoad = checkAcceptedMaxLoad($_SERVER['PHP_SELF']);
+
   if ($MaxLoad) {
     $load = sys_getloadavg();
     if ($load[0] > $MaxLoad) {

--- a/www/commit.php
+++ b/www/commit.php
@@ -11,12 +11,15 @@
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/cache-commit.php');
 	require_once($_SERVER['DOCUMENT_ROOT'] . '/../include/getvalues.php');
 
-        if (!$User->id) {
-          header("HTTP/1.1 422 Unprocessable Content");
-          die('something is wrong - you probably need to be <a href="/login.php">logged in</a>');
+	# if users must be logged in, and they aren't...
+	if (LOGIN_TO_VIEW_COMMIT && !$User->id) {
+	        # one message, twice invoked.
+	        $msg = 'You must be logged in to use this feature.';
+	        header('HTTP/1.1 503 ' . $msg);
+	        die($msg);
+	} else {
+		checkLoadBeforeProceeding();
         }
-
-	checkLoadBeforeProceeding();
 
 	$Debug = 0;
 

--- a/www/search.php
+++ b/www/search.php
@@ -15,7 +15,15 @@
 
 	require_once('Pager/Pager.php');
 
-	checkLoadBeforeProceeding();
+	# if users must be logged in, and they aren't...
+	if (LOGIN_TO_SEARCH && !$User->id) {
+	        # one message, twice invoked.
+	        $msg = 'You must be logged in to use this feature.';
+	        header('HTTP/1.1 503 ' . $msg);
+	        die($msg);
+	} else {
+	        checkLoadBeforeProceeding();
+        }
 
 	$Debug = 0;
 # this should only be referenced after it has been set.

--- a/www/vuxml.php
+++ b/www/vuxml.php
@@ -16,6 +16,16 @@
 
 	define('VUXMLURL',     'https://www.vuxml.org/freebsd/');
 
+	# if users must be logged in, and they aren't...
+	if (LOGIN_TO_VIEW_VUXML && !$User->id) {
+	        # one message, twice invoked.
+	        $msg = 'You must be logged in to use this feature.';
+	        header('HTTP/1.1 503 ' . $msg);
+	        die($msg);
+	} else {
+		checkLoadBeforeProceeding();
+        }
+
 	if (IsSet($_REQUEST['vid'])) {
 		$vid = pg_escape_string($db, $_REQUEST['vid']);
 


### PR DESCRIPTION
Let's enable a way to block them if they aren't logged in.

Before installing, add the following to `/usr/local/etc/freshports/constants.local.php`:

```
# re https://github.com/FreshPorts/freshports/issues/655
define('LOGIN_TO_VIEW_COMMIT', true);
define('LOGIN_TO_SEARCH',      true);
define('LOGIN_TO_VIEW_VUXML',  true);
```