### PR TITLE
Fix plain text search output

### DIFF
--- a/classes/display_commit.php
+++ b/classes/display_commit.php
@@ -25,6 +25,7 @@ class DisplayCommit
 	var $DaysMarkedAsNew = 10;
 	var $LocalResult;
 	var $HTML;
+	var $PlainText;
 
 	var $FlaggedCommits;
 
@@ -455,9 +456,7 @@ class DisplayCommit
 		return $this->HTML;
 	}
 
-	function CreateHTML1() {
-		GLOBAL $freshports_CommitMsgMaxNumOfLinesToShow;
-		
+	function CreatePlainText() {
 		$Debug = $this->Debug;
 
 		$URLBranchSuffix = BranchSuffix($this->BranchName);
@@ -470,255 +469,28 @@ class DisplayCommit
 
 		$NumRows = pg_num_rows($this->result);
 		if ($this->Debug) echo __FILE__ . ':' . __LINE__ . " Number of rows = $NumRows<br>\n";
-		if (!$NumRows) { 
-			$this->HTML = "<tr><td>\n<P>Sorry, nothing found in the database....</P>\n</td></tr>\n";
-			return $this->HTML;
+		if (!$NumRows) {
+			$this->PlainText = 'Sorry, nothing found in the database....';
+			return $this->PlainText;
 		}
-		
-		# if we have a UserID, but no flagged commits, grab them
-		#
-		if ($this->UserID && !IsSet($this->FlaggedCommits)) {
-			require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/commit_flag.php');
 
-			$FlaggedCommits = new CommitFlag($this->dbh);
-			$NumFlaggedCommits = $FlaggedCommits->Fetch($this->UserID);
-			for ($i = 0; $i < $NumFlaggedCommits; $i++) {
-				$FlaggedCommits->FetchNth($i);
-				$this->FlaggedCommits[$FlaggedCommits->commit_log_id] = $FlaggedCommits->commit_log_id;
-				if ($this->Debug) echo "fetching record # $i -> $FlaggedCommits->commit_log_id<br>";
-			}
-		}
-	
-		$GlobalHideLastChange = "N";
-
-		$this->HTML = "";
+		$this->PlainText = "";
 
 		# leave it all empty as a comparison point
-		$PreviousCommit = new Commit_Ports($this->dbh);
 
-		$NumberOfPortsInThisCommit = 0;
-		$MaxNumberPortsToShow      = 10;
-		$TooManyPorts = false;	# we might not show all of a commit, just for the big ones.
 		for ($i = 0; $i < $NumRows; $i++) {
 			$myrow = pg_fetch_array($this->result, $i);
-			if ($Debug) echo '<pre>processing row ' . $i . ' ' . $myrow['commit_log_id'] . ' ' . $myrow['message_id'] .  ' ' . $myrow['element_pathname'] . "</pre><br>\n";
-			unset($mycommit);
-			$mycommit = new Commit_Ports($this->dbh);
-			$mycommit->PopulateValues($myrow);
-
-			if ($mycommit->branch && $mycommit->branch != BRANCH_HEAD) {
-				$QueryArgs= '?branch=' . $mycommit->branch;
-			} else {
-				$QueryArgs = '';
-			}
-
-			$DetailsWillBePresented = !empty($mycommit->element_pathname);
-
-			// OK, while we have the log change log, let's put the port details here.
-
-			# not sure if this should be here or elsewhere
-			$Lines = 0;
-			if ($mycommit->commit_log_id != $PreviousCommit->commit_log_id) {
-				if ($Debug) echo 'This commit_log_id is different<br>';
-				if (($NumberOfPortsInThisCommit > $MaxNumberPortsToShow) && !$this->ShowAllPorts) {
-					if ($DetailsWillBePresented) {
-						$this->HTML .= '</ul>';
-					}
-					$this->HTML .= freshports_MorePortsToShow($PreviousCommit->message_id, $NumberOfPortsInThisCommit, $MaxNumberPortsToShow);
-				} else if ($i > 0 && $DetailsWillBePresented) {
-					$this->HTML .= '</ul>';
-				}
-				$TooManyPorts = false;
-				# count the number of ports in this commit.
-				# first time into the loop, this will be executed.
-				$NumberOfPortsInThisCommit = 0;
-				$MaxNumberPortsToShow = 10;
-
-				if ($mycommit->commit_date != $PreviousCommit->commit_date) {
-					$this->HTML .= '<tr><td class="accent">' . "\n";
-					$this->HTML .= '   ' . FormatTime($mycommit->commit_date, 0, "l, j M Y") . "\n";
-					$this->HTML .= "</td></tr>\n\n";
-				}
-
-				global $freshports_mail_archive;
-
-				$this->HTML .= "<tr><td class=\"commit-details\">\n";
-
-				$this->HTML .= '<span class="meta">';
-				$this->HTML .= $mycommit->commit_time . ' ';
-
-				#
-				# THIS CODE IS SIMILAR TO THAT IN classes/display_commit.php & classes/port-display.php
-				#
-				#
-				# the committer may not be the author
-				# committer name and author name came into the database with git.
-				# For other commits, such as git or cvs, those fields will not be present.
-				# committer will always be present.
-				#
-				$CommitterIsNotAuthor = !empty($mycommit->author_name) && !empty($mycommit->committer_name) && $mycommit->author_name != $mycommit->committer_name;
-
-				# if no author name, it's an older commit, and we have only committer
-				if (empty($mycommit->committer_name)) {
-					$this->HTML .= freshports_CommitterEmailLink_Old($mycommit->committer);
-				} else {
-					$this->HTML .= freshports_AuthorEmailLink($mycommit->committer_name, $mycommit->committer_email);
-					# display the committer id, just because
-					$this->HTML .= '&nbsp;(' . $mycommit->committer . ')';
-				}
-
-				# after the committer, display a search-by-committer link
-				$this->HTML .= '&nbsp;' . freshports_Search_Committer($mycommit->committer);
-
-				if ($CommitterIsNotAuthor) {
-					$this->HTML .= '&nbsp;Author:&nbsp;' . freshports_AuthorEmailLink($mycommit->author_name, $mycommit->author_email);
-				}
-				$this->HTML .= '</span>';
-			}
-
-				$NumberOfPortsInThisCommit++;
-				if (($NumberOfPortsInThisCommit > $MaxNumberPortsToShow) && !$this->ShowAllPorts) {
-					$TooManyPorts = true;
-				}
-
-				if ($Debug) echo 'at too many<br>';
-
-				if ($DetailsWillBePresented) {
-					$this->HTML .= '<ul class="element-list">' . "\n";
-				}
-
-
-
-
-				if (!$TooManyPorts) {
-					if ($DetailsWillBePresented) {
-						$this->HTML .= '<li>';
-					}
-					if (!$DetailsWillBePresented) {
-						# we do nothing
-						# this is a non-port. All the rest of the stuff is not displayed
-						if ($Debug) echo 'details will not be presented<br>';
-					} else {
-						syslog(LOG_NOTICE, 'We have non-port where element_pathname is not empty - 2nd location: ' . $mycommit->element_pathname);
-
-						# This is a non-port element...
-						$this->HTML .= '<span class="element-details">';
-
-						$PathName = preg_replace('|^/?ports/|', '', $mycommit->element_pathname);
-						if ($Debug) echo "PathName='$PathName' " . " reponame='" . $mycommit->repo_name . "'<br>";
-						switch ($mycommit->repo_name)
-						{
-							case 'ports':
-								// strip off the leading directories
-								if ($Debug && !empty($mycommit->branch)) echo 'Branch is ' . $mycommit->branch . '<br>';
-								if (empty($mycommit->branch) || $mycommit->branch == BRANCH_HEAD) {
-									if ($Debug) echo 'replacing head<br>';
-									$PathName = preg_replace('|^head/|', '', $PathName);
-								} else {
-									if ($Debug) echo 'replacing branches<br>';
-									$PathName = preg_replace('|^branches/' . $mycommit->branch . '/|', '', $PathName);
-								}
-								break;
-						}
-
-						if ($PathName != $mycommit->element_pathname) {
-							# the replace changes encoded / to plain text / - not sure why may have been present
-							$this->HTML .= '<a href="/' . str_replace('%2F', '/', $PathName);
-							if (!empty($mycommit->port)) $this->HTML .= '/';
-							$this->HTML .= $QueryArgs . '"';
-							$this->HTML .= ' title="' . $PathName . ': ' . $mycommit->short_description . '"';
-							$this->HTML .= '>' . $PathName. '</a>';
-						} else {
-							#$this->HTML .= '<a href="' . FRESHPORTS_FREEBSD_CVS_URL . $PathName . '#rev' . $mycommit->revision . '">' . $PathName . '</a>';
-							$this->HTML .= $PathName;
-						}
-
-						$this->HTML .= "</span>\n"; /* element-details*/
-
-						if (IsSet($mycommit->category) && $mycommit->category != '') {
-							// indicate if this port has been removed from cvs
-							if ($mycommit->status == "D") {
-								$this->HTML .= " " . freshports_Deleted_Icon_Link() . "\n";
-							}
-
-							// indicate if this port needs refreshing from CVS
-							if ($mycommit->needs_refresh) {
-								$this->HTML .= " " . freshports_Refresh_Icon_Link() . "\n";
-							}
-							if ($mycommit->date_added > Time() - 3600 * 24 * $this->DaysMarkedAsNew) {
-								$MarkedAsNew = "Y";
-								$this->HTML .= freshports_New_Icon() . "\n";
-							}
-
-							if ($mycommit->forbidden) {
-								$this->HTML .= ' ' . freshports_Forbidden_Icon_Link() . "\n";
-							}
-
-							if ($mycommit->broken) {
-								$this->HTML .= ' '. freshports_Broken_Icon_Link() . "\n";
-							}
-
-							if ($mycommit->deprecated) {
-								$this->HTML .= ' '. freshports_Deprecated_Icon_Link() . "\n";
-							}
-
-							if ($mycommit->expiration_date) {
-								if (date('Y-m-d') >= $mycommit->expiration_date) {
-									$this->HTML .= freshports_Expired_Icon_Link($mycommit->expiration_date) . "\n";
-								} else {
-									$this->HTML .= freshports_Expiration_Icon_Link($mycommit->expiration_date) . "\n";
-								}
-							}
-
-							if ($mycommit->ignore) {
-								$this->HTML .= ' '. freshports_Ignore_Icon_Link() . "\n";
-							}
-
-							if ($mycommit->vulnerable_current) {
-								$this->HTML .= '&nbsp;' . freshports_VuXML_Icon() . '&nbsp;';
-							}
-
-							if ($mycommit->restricted) {
-								$this->HTML .= freshports_Restricted_Icon_Link($mycommit->restricted) . '&nbsp;';
-							}
-
-							if ($mycommit->no_cdrom) {
-								$this->HTML .= freshports_No_CDROM_Icon_Link($mycommit->no_cdrom) . '&nbsp;';
-							}
-
-							if ($mycommit->is_interactive) {
-								$this->HTML .= freshports_Is_Interactive_Icon_Link($mycommit->is_interactive) . '&nbsp;';
-							}
-
-						}
-
-					if ($DetailsWillBePresented) {
-						$this->HTML .= "</li>\n";
-					}
-
-					GLOBAL $freshports_CommitMsgMaxNumOfLinesToShow;
-					if ($this->ShowEntireCommit) {
-						$Lines = 0;
-					} else {
-						$Lines = $freshports_CommitMsgMaxNumOfLinesToShow;
-					}
-				} # !$TooManyPorts
-
-			}
-
-			$PreviousCommit = $mycommit;
+			$this->PlainText .= $myrow['message_id'] . "\n";
 		}
 
-		$this->HTML .= _DisplayEndOfCommit($PreviousCommit, $Lines);
-
 		unset($mycommit);
-		
-		return $this->HTML;
+
+		return $this->PlainText;
 	}
 
 	function SetBranch($BranchName) {
 		# usually, this is set during __construct
 		$this->BranchName = $BranchName;
 	}
-	
+
 }

--- a/www/search.php
+++ b/www/search.php
@@ -99,8 +99,8 @@
 
 
 	$SearchTypeToFieldMap = array(
-        SEARCH_FIELD_AUTHOR_NAME          => 'CL.author_name',
-        SEARCH_FIELD_AUTHOR_EMAIL         => 'CL.author_email',
+	    SEARCH_FIELD_AUTHOR_NAME          => 'CL.author_name',
+	    SEARCH_FIELD_AUTHOR_EMAIL         => 'CL.author_email',
 	    SEARCH_FIELD_COMMITMESSAGE        => 'CL.description',
 	    SEARCH_FIELD_COMMITTER            => 'CL.committer',
 	    SEARCH_FIELD_COMMITTER_EMAIL      => 'CL.committer_email',
@@ -420,7 +420,8 @@
 		# are we setting the whole SQL condition or just the operator and the value?
 		$sqlSetAll = false;
 
-		if ($Debug) echo "at line " . __FILE__ . '::' . __LINE__ . " stype='$stype'<br>";
+		# the \n is for better formatting when reading plain text debug output
+		if ($Debug) echo "at line " . __FILE__ . '::' . __LINE__ . " stype='$stype'<br>\n";
 
 
 		if ($output_format == OUTPUT_FORMAT_DEPENDS && $stype == SEARCH_FIELD_NAME) {
@@ -447,7 +448,7 @@
                     } else {
                         $Like = 'ILIKE';
                     }
-                    if ($Debug) echo 'invoking WildCardQuery for match<br>';
+                    if ($Debug) echo 'invoking WildCardQuery for match<br>\n';
                     $sqlUserSpecifiedCondition = WildCardQuery($db, $stype, $Like, $WildCardMatch);
                     break;
 
@@ -497,7 +498,7 @@
 		  }  # $stype != SEARCH_FIELD_PACKAGE
 		} # not OUTPUT_FORMAT_DEPENDS
 
-		if ($Debug && IsSet($sqlUserSpecifiedCondition)) echo "at line " . __FILE__ . '::' . __LINE__ . " sqlUserSpecifiedCondition is: $sqlUserSpecifiedCondition<br>";
+		if ($Debug && IsSet($sqlUserSpecifiedCondition)) echo "at line " . __FILE__ . '::' . __LINE__ . " sqlUserSpecifiedCondition is: $sqlUserSpecifiedCondition<br>\n";
 
 		#
 		# include/exclude deleted ports
@@ -632,15 +633,15 @@
 		    require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/display_commit.php');
 
 		    if ($include_src_commits) {
-		      if ($Debug) echo 'searching src<br>';
+		      if ($Debug) echo 'searching src<br>\n';
 		      require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/commits_by_committer.php');
 		      $Commits = new CommitsByCommitter($db);
 		    } else {
-		      if ($Debug) echo 'not searching src<br>';
+		      if ($Debug) echo 'not searching src<br>\n';
 		      require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/port_commits_by_committer.php');
 		      $Commits = new PortCommitsByCommitter($db);
 		    }
-		    if ($Debug) echo 'searching by committer for ' . htmlentities($query) . '<br>';
+		    if ($Debug) echo 'searching by committer for ' . htmlentities($query) . '<br>\n';
 		    $Commits->CommitterSet($query);
 
 		    $Commits->Debug = $Debug;
@@ -674,8 +675,7 @@
 		    $result     = $Commits->LocalResult;
 		    if ($Debug) {
 		        if ($result) {
-		             echo "
-<br>we have a result for $stype<br>\n";
+		            echo "\n<br>" . __FILE__ . '::' . __LINE__ . " we have a result for $stype<br>\n";
 			}
 		    }
 		    break;
@@ -719,8 +719,7 @@
 		    $result     = $Commits->LocalResult;
 		    if ($Debug) {
 		        if ($result) {
-		            echo "
-<br>we have a result for $stype<br>\n";
+		            echo "\n<br>" . __FILE__ . '::' . __LINE__ . " we have a result for $stype<br>\n";
 		    	}
 		    }
 		    break;
@@ -782,8 +781,7 @@
 			$result = $Commits->LocalResult;
 			if ($Debug) {
 				if ($result) {
-					echo "
-<br>we have a result for $stype<br>\n";
+				        echo "\n<br>" . __FILE__ . '::' . __LINE__ . " we have a result for $stype<br>\n";
 				}
 			}
 
@@ -852,8 +850,7 @@
 			$result = $Ports->LocalResult;
 			if ($Debug) {
 				if ($result) {
-					echo "
-<br>we have a result for $stype<br>\n";
+				        echo "\n<br>" . __FILE__ . '::' . __LINE__ . " we have a result for $stype<br>\n";
 				}
 			}
 			break;
@@ -960,9 +957,9 @@ JOIN element_pathname EP on E.id = EP.element_id
 
 
 			$AddRemoveExtra  = "?query=" . htmlentities($query). "+stype=$stype+num=$num+method=$method";
-			if ($Debug) echo "\$AddRemoveExtra = '$AddRemoveExtra'\n<br>";
+			if ($Debug) echo "\$AddRemoveExtra = '$AddRemoveExtra'\n<br>\n";
 			$AddRemoveExtra = pg_escape_string($db, $AddRemoveExtra);
-			if ($Debug) echo "\$AddRemoveExtra = '$AddRemoveExtra'\n<br>";
+			if ($Debug) echo "\$AddRemoveExtra = '$AddRemoveExtra'\n<br>\n";
 
 			#
 			# construct the query to determine the number of rows.
@@ -975,8 +972,8 @@ JOIN element_pathname EP on E.id = EP.element_id
                         }
 
 			if ($Debug) {
-				echo __FILE__ . '::' . __LINE__ . ' says:<br>';
-				echo "<pre>$sql</pre>\n";
+				echo __FILE__ . '::' . __LINE__ . ' says:<br>\n';
+				echo "\n<pre>\n$sql\n</pre>\n";
 			}
 
 			# this may be interesting to figure out params.
@@ -992,7 +989,7 @@ JOIN element_pathname EP on E.id = EP.element_id
 			$NumberOfCommits = $NumFound;
 
 			if ($Debug) {
-				echo "\$NumFound = '$NumFound' on line " . __LINE__ . "<br>";
+				echo "\$NumFound = '$NumFound' on line " . __LINE__ . "<br>\n";
 			}
 
 			$NumFetches = 0;
@@ -1037,7 +1034,7 @@ JOIN element_pathname EP on E.id = EP.element_id
 				}
 
 				if ($Debug) {
-                                        echo __FILE__ . '::' . __LINE__ . ' says:<br>';
+                                        echo __FILE__ . '::' . __LINE__ . ' says:<br>\n';
 					echo "<pre>$sql</pre>\n";
 				}
 
@@ -1056,14 +1053,15 @@ JOIN element_pathname EP on E.id = EP.element_id
 
 				if ($Debug) {
 					if ($result) {
-						echo "
-<br>we have a result for $stype via 'default'<br>\n";
+						echo "\n<br>" . __FILE__ . '::' . __LINE__ . " we have a result for $stype via 'default'<br>\n";
 					}
 				}
 			} # $NumFound > 0
 
 		} // end of non-committer search  ## I think this is the end of the default option
 
+		# this code has been around for decades
+		# my initial goal: see the terms used for searching
 		$fp = fopen($logfile, "a");
 		if ($fp) {
 			switch ($method) {
@@ -1083,7 +1081,6 @@ JOIN element_pathname EP on E.id = EP.element_id
 			define_syslog_variables();
 			syslog(LOG_ERR, "FreshPorts could not open the search log file: $logfile");
 		}
-
 
 		$Port = new Port($db);
 		$Port->LocalResult = $result;
@@ -1287,11 +1284,11 @@ Special searches:
 			echo "<tr><td>\n";
 		}
 
-	}  // end of putting out HTML output
+	}  // end of putting out HTML output - OUTPUT_FORMAT_HTML
 
-	if ($Debug) echo 'in debug mode<br>';
+	if ($Debug) echo __FILE__ . '::' . __LINE__ . "in debug mode<br>\n";
 
-	if ($Debug && $WeHaveToSearch) echo 'we have to search<br>';
+	if ($Debug && $WeHaveToSearch) echo "we have to search<br>\n";
 
 	if ($WeHaveToSearch) {
 		if (IsSet($NumFetches) && $NumFetches == 0) {
@@ -1309,7 +1306,7 @@ Special searches:
                 case SEARCH_FIELD_COMMITMESSAGE:
                 case SEARCH_FIELD_PATHNAME:
 		          $NumFetches = min($num, $NumberOfCommits);
-		          if ($Debug) echo 'here we are<br>';
+		          if ($Debug) echo __FILE__ . '::' . __LINE__ . "here we are<br>\n";
 		          if ($NumFetches != $NumberOfCommits) {
 		            $MoreToShow = 1;
 		          } else {
@@ -1317,11 +1314,11 @@ Special searches:
 		          }
 
 		          $NumPortsFound = 'Number of commits: ' . $NumberOfCommits;
-		          if ($NumFound > $PageSize) {
+		          if ($output_format == OUTPUT_FORMAT_HTML && ($NumFound > $PageSize)) {
 		            $NumPortsFound .= " (showing only $NumOnThisPage on this page)";
 			  }
 
-			  if ($Debug) echo "NumPortsFound = '$NumPortsFound'<br>";
+			  if ($Debug) echo "NumPortsFound = '$NumPortsFound'<br>\n";
                   break;
 
                 default:
@@ -1340,7 +1337,7 @@ Special searches:
                     break;
 		} /* switch */
 
-                if ($Debug) echo 'here we are2<br>';
+                if ($Debug) echo __FILE__ . '::' . __LINE__ . "here we are2<br>\n";
                 switch ($stype) {
                     case SEARCH_FIELD_AUTHOR_NAME:
                     case SEARCH_FIELD_AUTHOR_EMAIL:
@@ -1349,20 +1346,25 @@ Special searches:
                     case SEARCH_FIELD_COMMITTER_EMAIL:
                     case SEARCH_FIELD_COMMITMESSAGE:
                     case SEARCH_FIELD_PATHNAME:
-                        if ($Debug) echo __FILE__ . '::' . __LINE__ . ' says hi<br>';
+                        if ($Debug) echo __FILE__ . '::' . __LINE__ . " says hi<br>\n";
                         require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/display_commit.php');
 
-                        if ($Debug) echo 'time to display!';
+                        if ($Debug) echo "time to display!<br>\n";
                         $DisplayCommit = new DisplayCommit($db, $Commits->LocalResult);
-                        $links = $Pager->GetLinks();
+                        if ($output_format !== OUTPUT_FORMAT_PLAIN_TEXT) {
+                                $links = $Pager->GetLinks();
 
-                        $HTML .= $NumPortsFound . ' ' . $links['all'];
-                        $HTML .= $DisplayCommit->CreateHTML();
-                        $HTML .= '<tr><td>' . $NumPortsFound . ' ' . $links['all'] . '</td></tr>';
+                                $HTML .= $NumPortsFound . ' ' . $links['all'];
+
+                                $HTML .= $DisplayCommit->CreateHTML();
+                                $HTML .= '<tr><td>' . $NumPortsFound . ' ' . $links['all'] . '</td></tr>';
+                        } else {
+                                $HTML .= $DisplayCommit->CreatePlainText();
+                        }
                         break;
 
                     default:
-                        if ($Debug) echo __FILE__ . '::' . __LINE__ . ' says hi<br>';
+                        if ($Debug) echo __FILE__ . '::' . __LINE__ . " says hi<br>\n";
                         require_once($_SERVER['DOCUMENT_ROOT'] . '/../classes/port-display.php');
 
                         $links = $Pager->GetLinks();
@@ -1389,7 +1391,7 @@ Special searches:
                                 break;
                         } /* switch output */
 
-                        if ($Debug) echo 'NumFetches = ' . $NumFetches . '<br>';
+                        if ($Debug) echo 'NumFetches = ' . $NumFetches . "<br>\n";
                         for ($i = 0; $i < $NumFetches; $i++) {
                             $Port->FetchNth($i);
                             $port_display->SetPort($Port, $Branch);
@@ -1421,7 +1423,7 @@ Special searches:
                         }
                 } /* switch */
 
-			if ($Debug) echo 'WHAT IS THIS?<br>';
+		if ($Debug) echo "WHAT IS THIS?<br>\n";
 
 		} /* NumFetches  != 0 */
 	} // $WeHaveToSearch


### PR DESCRIPTION
It was displaying unrendered HTML when searching by:

* committer_email
* plain text

Fix that by creating a PlainText() function for classes/display_commit.php

While there, delete CreateHTML1(), which I think was a backup when CreateHTML() was rewritten.

While here, add lots of \n to add reading of the debug output. Add some more line numbers to the debug output.
When displaying plaintext output, invoke the newly created PlainText(), not the existing CreateHTML()

fixes #666